### PR TITLE
add run_depend of app_manager in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Another way to notify the location is to define them in `<export>` tag in `packa
 <!-- package_root/package.xml -->
 <package>
   ...
+  <run_depend>app_manager</run_depend>
+  ...
   <export>
     <app_manager app_dir="${prefix}/apps"/>
   </export>


### PR DESCRIPTION
@k-okada 

I heard run_depend of app_manager is also needed to use app_manager by @knorth55.