### PR TITLE
use app_manager/example-min

### DIFF
--- a/test/appA.app
+++ b/test/appA.app
@@ -1,5 +1,5 @@
 display: Android Joystick
 description: Control the TurtleBot with an Android device
 platform: turtlebot
-launch: roslaunch/example-min.launch
+launch: app_manager/example-min.launch
 interface: app_manager/empty.interface

--- a/test/resources/example-min.launch
+++ b/test/resources/example-min.launch
@@ -1,0 +1,7 @@
+<launch>
+  <!-- $(anon talker) creates an anonymous name for this node -->
+  <node name="$(anon talker)" pkg="rospy_tutorials" type="talker.py"
+        launch-prefix="xterm -e" />
+  <node name="$(anon listener)" pkg="rospy_tutorials" type="listener.py"
+        launch-prefix="xterm -e"/>
+</launch>

--- a/test/test_app.py
+++ b/test/test_app.py
@@ -154,7 +154,8 @@ class AppTest(unittest.TestCase):
         self.assertEquals("Android Joystick", ad.display_name)
         self.assertEquals("Control the TurtleBot with an Android device", ad.description)
         self.assertEquals("turtlebot", ad.platform)
-        self.assertEquals(os.path.join(rl_dir, 'resources', 'example-min.launch'), ad.launch)
+        #self.assertEquals(os.path.join(rl_dir, 'resources', 'example-min.launch'), ad.launch) # example-min.launch location changed due to https://github.com/PR2/app_manager/pull/15
+        self.assertEquals(os.path.join(rospack.get_path(PKG), 'test', 'resources', 'example-min.launch'), ad.launch)
         self.assert_(isinstance(ad.interface, Interface))
         self.assertEquals({}, ad.interface.subscribed_topics)
         self.assertEquals({}, ad.interface.published_topics)
@@ -195,7 +196,8 @@ class AppTest(unittest.TestCase):
         self.assertEquals("Android Joystick", ad.display_name)
         self.assertEquals("Control the TurtleBot with an Android device", ad.description)
         self.assertEquals("turtlebot", ad.platform)
-        self.assertEquals(os.path.join(rl_dir, 'resources', 'example-min.launch'), ad.launch)
+        #self.assertEquals(os.path.join(rl_dir, 'resources', 'example-min.launch'), ad.launch) # example-min.launch location changed due to https://github.com/PR2/app_manager/pull/15
+        self.assertEquals(os.path.join(test_dir, 'resources', 'example-min.launch'), ad.launch)
         self.assert_(isinstance(ad.interface, Interface))
         self.assertEquals({}, ad.interface.subscribed_topics)
         self.assertEquals({}, ad.interface.published_topics)


### PR DESCRIPTION
since talker.py was removed from rospy in melodic https://github.com/ros/ros_comm/pull/1847