### PR TITLE
Add app manager plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,13 @@ namespace: "/robot/application"
 You can define `app_manager` plugins as below in app file such as `test.app`.
 
 ```yaml
-plugins: # plugin definitions
+# app definitions
+display: Test app
+platform: all
+launch: test_app_manager/test_app.xml
+interface: test_app_manager/test_app.interface
+# plugin definitions
+plugins:
   - name: mail_notifier_plugin  # name to identify this plugin
     type: app_notifier/mail_notifier_plugin  # plugin type
     launch_args:  # arguments for plugin launch file

--- a/README.md
+++ b/README.md
@@ -124,6 +124,51 @@ message: "app [app_manager/appA] started"
 namespace: "/robot/application"
 ```
 
+## Plugins
+
+You can define `app_manager` plugins as below in app file such as `test.app`.
+
+```yaml
+plugins: # plugin definitions
+  - name: mail_notifier_plugin  # name to identify this plugin
+    type: app_notifier/mail_notifier_plugin  # plugin type
+    launch_args:  # arguments for plugin launch file
+      - foo: hello
+    launch_arg_yaml: /etc/mail_notifier_launch_arg.yaml  # argument yaml file for plugin launch file
+    # in this case, these arguments will be passed.
+    # {"hoge": 100, "fuga": 30, "bar": 10} will be passed to start plugin
+    # {"hoge": 50, "fuga": 30} will be passed to stop plugin
+    plugin_args:  # arguments for plugin function
+      - hoge: 10
+      - fuga: 30
+    start_plugin_args:  # arguments for start plugin function
+      - hoge: 100  # arguments for start plugin function arguments (it overwrites plugin_args hoge: 10 -> 100)
+      - bar: 10
+    stop_plugin_args:  # arguments for stop plugin function
+      - hoge: 50  # arguments for stop plugin function arguments (it overwrites plugin_args hoge: 10 -> 50)
+    plugin_arg_yaml: /etc/mail_notifier_plugin_arg.yaml  # argument yaml file for plugin function arguments
+  - name: rosbag_recorder_plugin  # another plugin
+    type app_recorder/rosbag_recorder_plugin
+    launch_args:
+      rosbag_path: /tmp
+      rosbag_title: test.bag
+      compress: true
+      rosbag_topic_names:
+        - /rosout
+        - /tf
+        - /tf_static
+plugin_order: # plugin running orders. if you don't set field, plugin will be run in order in plugins field
+  start_plugin_order:  # start plugin running order
+    - rosbag_recorder_plugin  # 1st plugin name
+    - mail_notifier_plugin  #2nd plugin name
+  stop_plugin_order:  # start plugin running order
+    - rosbag_recorder_plugin
+    - mail_notifier_plugin
+```
+
+Sample plugin repository is [knorth55/app_manager_utils](https://github.com/knorth55/app_manager_utils).
+
+For more detailed information, please read [#25](https://github.com/PR2/app_manager/pull/25).
 
 ## Maintainer
 

--- a/scripts/app_manager
+++ b/scripts/app_manager
@@ -9,6 +9,7 @@ import rospkg
 from argparse import ArgumentParser
 import os
 import sys
+import yaml
 
 import app_manager
 import rospy
@@ -25,15 +26,19 @@ def main():
     args = parser.parse_args(argv[1:])
 
     applist = []
+    plugin_yamls = []
     rospack = rospkg.RosPack()
     depend_pkgs = rospack.get_depends_on('app_manager', implicit=False)
 
     rospy.loginfo("Loading from plugin definitions")
     for depend_pkg in depend_pkgs:
-        m = rospack.get_manifest(depend_pkg)
-        app_dir = m.get_export('app_manager', 'app_dir')
-        if len(app_dir) != 0:
-            applist += app_dir
+        manifest = rospack.get_manifest(depend_pkg)
+        app_dirs = manifest.get_export('app_manager', 'app_dir')
+        plugin_yaml = manifest.get_export('app_manager', 'plugin')
+        if len(app_dirs) != 0:
+            applist += app_dirs
+        if len(plugin_yaml) != 0:
+            plugin_yamls += plugin_yaml
 
     if args.applist is not None:
         rospy.loginfo("Loading applist from --applist option")
@@ -46,6 +51,14 @@ def main():
 
     if len(applist) == 0:
         rospy.logwarn('No applist directory found.')
+
+    plugins = None
+    for plugin_yaml in plugin_yamls:
+        with open(plugin_yaml) as f:
+            plugin = yaml.safe_load(f)
+        if plugins is None:
+            plugins = []
+        plugins += plugin
 
     robot_name = rospy.get_param('/robot/name', 'robot')
     robot_type = rospy.get_param("/robot/type", None)
@@ -76,7 +89,8 @@ def main():
             rospy.logerr("Failed to load exchange: {}".format(e))
             sys.exit(1)
 
-    am = app_manager.AppManager(robot_name, interface_master, app_list, exchange)
+    am = app_manager.AppManager(
+        robot_name, interface_master, app_list, exchange, plugins)
 
     rospy.on_shutdown(am.shutdown)
 

--- a/scripts/app_manager
+++ b/scripts/app_manager
@@ -56,12 +56,10 @@ def main():
     if len(applist) == 0:
         rospy.logwarn('No applist directory found.')
 
-    plugins = None
+    plugins = []
     for plugin_yaml in plugin_yamls:
         with open(plugin_yaml) as f:
             plugin = yaml.safe_load(f)
-        if plugins is None:
-            plugins = []
         plugins += plugin
 
     robot_name = rospy.get_param('/robot/name', 'robot')

--- a/scripts/app_manager
+++ b/scripts/app_manager
@@ -38,11 +38,11 @@ def main():
         if len(app_dirs) != 0:
             applist += app_dirs
             for app_dir in app_dirs:
-                rospy.loginfo('Loading app in {}'.format(app_dir))
+                rospy.logdebug('Loading app in {}'.format(app_dir))
         if len(plugin_yaml) != 0:
             plugin_yamls += plugin_yaml
             for plugin_y in plugin_yaml:
-                rospy.loginfo('Loading plugin in {}'.format(plugin_y))
+                rospy.logdebug('Loading plugin in {}'.format(plugin_y))
 
     if args.applist is not None:
         rospy.loginfo("Loading applist from --applist option")

--- a/scripts/app_manager
+++ b/scripts/app_manager
@@ -37,8 +37,12 @@ def main():
         plugin_yaml = manifest.get_export('app_manager', 'plugin')
         if len(app_dirs) != 0:
             applist += app_dirs
+            for app_dir in app_dirs:
+                rospy.loginfo('Loading app in {}'.format(app_dir))
         if len(plugin_yaml) != 0:
             plugin_yamls += plugin_yaml
+            for plugin_y in plugin_yaml:
+                rospy.loginfo('Loading plugin in {}'.format(plugin_y))
 
     if args.applist is not None:
         rospy.loginfo("Loading applist from --applist option")

--- a/src/app_manager/__init__.py
+++ b/src/app_manager/__init__.py
@@ -35,6 +35,7 @@
 from .app import AppDefinition
 from .app_manager import AppManager
 from .app_list import AppList, get_default_applist_directory
+from .app_manager_plugin import AppManagerPlugin
 from .exchange import Exchange
 from .exceptions import AppException, NotFoundException, \
      InvalidAppException, LaunchException, InternalAppException

--- a/src/app_manager/app.py
+++ b/src/app_manager/app.py
@@ -226,7 +226,7 @@ def _AppDefinition_load_clients_entry(app_data, appfile="UNKNOWN"):
 
 def _AppDefinition_load_plugins_entry(app_data, appfile="UNKNOWN"):
     """
-    @raise InvalidAppExcetion: if app definition is invalid.
+    @raise InvalidAppException: if app definition is invalid.
     """
     # load/validate launch entry
     try:

--- a/src/app_manager/app.py
+++ b/src/app_manager/app.py
@@ -75,9 +75,9 @@ class Client(object):
                
 class AppDefinition(object):
     __slots__ = ['name', 'display_name', 'description', 'platform',
-                 'launch', 'interface', 'clients', 'icon']
+                 'launch', 'interface', 'clients', 'icon', 'plugins']
     def __init__(self, name, display_name, description, platform,
-                 launch, interface, clients, icon=None):
+                 launch, interface, clients, icon=None, plugins=None):
         self.name = name
         self.display_name = display_name
         self.description = description
@@ -86,6 +86,7 @@ class AppDefinition(object):
         self.interface = interface
         self.clients = clients
         self.icon = icon
+        self.plugins = plugins
 
     def __repr__(self):
         d = {}
@@ -222,6 +223,21 @@ def _AppDefinition_load_clients_entry(app_data, appfile="UNKNOWN"):
         clients.append(Client(client_type, manager_data, app_data))
     return clients
 
+
+def _AppDefinition_load_plugins_entry(app_data, appfile="UNKNOWN"):
+    """
+    @raise InvalidAppExcetion: if app definition is invalid.
+    """
+    # load/validate launch entry
+    try:
+        plugins = app_data.get('plugins', '')
+        if plugins == '':
+            return None
+        return plugins
+    except ValueError as e:
+        raise InvalidAppException("Malformed appfile [%s]: bad plugins entry: %s"%(appfile, e))
+
+
 def load_AppDefinition_from_file(appfile, appname):
     """
     @raise InvalidAppExcetion: if app definition is invalid.
@@ -242,9 +258,10 @@ def load_AppDefinition_from_file(appfile, appname):
         interface = _AppDefinition_load_interface_entry(app_data, appfile)
         clients = _AppDefinition_load_clients_entry(app_data, appfile)
         icon = _AppDefinition_load_icon_entry(app_data, appfile)
+        plugins = _AppDefinition_load_plugins_entry(app_data, appfile)
 
     return AppDefinition(appname, display_name, description, platform,
-                         launch, interface, clients, icon)
+                         launch, interface, clients, icon, plugins)
     
 def load_AppDefinition_by_name(appname):
     """

--- a/src/app_manager/app.py
+++ b/src/app_manager/app.py
@@ -75,9 +75,9 @@ class Client(object):
                
 class AppDefinition(object):
     __slots__ = ['name', 'display_name', 'description', 'platform',
-                 'launch', 'interface', 'clients', 'icon', 'plugins']
+                 'launch', 'interface', 'clients', 'icon', 'plugins', 'plugin_order']
     def __init__(self, name, display_name, description, platform,
-                 launch, interface, clients, icon=None, plugins=None):
+                 launch, interface, clients, icon=None, plugins=None, plugin_order=None):
         self.name = name
         self.display_name = display_name
         self.description = description
@@ -87,6 +87,7 @@ class AppDefinition(object):
         self.clients = clients
         self.icon = icon
         self.plugins = plugins
+        self.plugin_order = plugin_order
 
     def __repr__(self):
         d = {}
@@ -238,6 +239,20 @@ def _AppDefinition_load_plugins_entry(app_data, appfile="UNKNOWN"):
         raise InvalidAppException("Malformed appfile [%s]: bad plugins entry: %s"%(appfile, e))
 
 
+def _AppDefinition_load_plugin_order_entry(app_data, appfile="UNKNOWN"):
+    """
+    @raise InvalidAppException: if app definition is invalid.
+    """
+    # load/validate launch entry
+    try:
+        plugin_order = app_data.get('plugin_order', '')
+        if plugin_order == '':
+            return None
+        return plugin_order
+    except ValueError as e:
+        raise InvalidAppException("Malformed appfile [%s]: bad plugin_order entry: %s"%(appfile, e))
+
+
 def load_AppDefinition_from_file(appfile, appname):
     """
     @raise InvalidAppExcetion: if app definition is invalid.
@@ -259,9 +274,11 @@ def load_AppDefinition_from_file(appfile, appname):
         clients = _AppDefinition_load_clients_entry(app_data, appfile)
         icon = _AppDefinition_load_icon_entry(app_data, appfile)
         plugins = _AppDefinition_load_plugins_entry(app_data, appfile)
+        plugin_order = _AppDefinition_load_plugin_order_entry(app_data, appfile)
 
     return AppDefinition(appname, display_name, description, platform,
-                         launch, interface, clients, icon, plugins)
+                         launch, interface, clients, icon,
+                         plugins, plugin_order)
     
 def load_AppDefinition_by_name(appname):
     """

--- a/src/app_manager/app_manager.py
+++ b/src/app_manager/app_manager.py
@@ -285,23 +285,29 @@ class AppManager(object):
                 self._current_plugins = []
                 for app_plugin in app.plugins:
                     app_plugin_type = app_plugin['type']
-                    plugin = [p for p in self._plugins if p['name'] == app_plugin_type][0]
-                    self._current_plugins.append((app_plugin, plugin))
-                    if 'launch' in plugin and plugin['launch']:
-                        plugin_launch_file = find_resource(plugin['launch'])
-                        if 'launch_args' in app_plugin:
-                            plugin_launch_args = []
-                            for k, v in app_plugin['launch_args'].items():
-                                if isinstance(v, list):
-                                    v = " ".join(map(str, v))
-                                plugin_launch_args.append("{}:={}".format(k, v))
-                        else:
-                            plugin_launch_args = None
-                        rospy.loginfo(
-                            "Launching plugin: {} {}".format(
-                                plugin_launch_file, plugin_launch_args))
-                        plugin_launch_files.append(
-                            (plugin_launch_file, plugin_launch_args))
+                    try:
+                        plugin = next(
+                            p for p in self._plugins if p['name'] == app_plugin_type)
+                        self._current_plugins.append((app_plugin, plugin))
+                        if 'launch' in plugin and plugin['launch']:
+                            plugin_launch_file = find_resource(plugin['launch'])
+                            if 'launch_args' in app_plugin:
+                                plugin_launch_args = []
+                                for k, v in app_plugin['launch_args'].items():
+                                    if isinstance(v, list):
+                                        v = " ".join(map(str, v))
+                                    plugin_launch_args.append("{}:={}".format(k, v))
+                            else:
+                                plugin_launch_args = None
+                            rospy.loginfo(
+                                "Launching plugin: {} {}".format(
+                                    plugin_launch_file, plugin_launch_args))
+                            plugin_launch_files.append(
+                                (plugin_launch_file, plugin_launch_args))
+                    except StopIteration:
+                        rospy.logerr(
+                            'There is no available app_manager plugin: {}'
+                            .format(app_plugin_type))
 
             #TODO:XXX This is a roslaunch-caller-like abomination.  Should leverage a true roslaunch API when it exists.
             self._launch = roslaunch.parent.ROSLaunchParent(

--- a/src/app_manager/app_manager.py
+++ b/src/app_manager/app_manager.py
@@ -246,7 +246,7 @@ class AppManager(object):
             self._status_pub.publish(AppStatus(AppStatus.INFO, 'launching %s'%(app.display_name)))
 
             plugin_launch_files = []
-            if self._plugins:
+            if app.plugins:
                 self._current_plugins = []
                 for app_plugin in app.plugins:
                     app_plugin_type = app_plugin['type']

--- a/src/app_manager/app_manager.py
+++ b/src/app_manager/app_manager.py
@@ -235,7 +235,7 @@ class AppManager(object):
             plugin_launch_files = []
             if self._plugins:
                 for plugin in self._plugins:
-                    if plugin['launch']:
+                    if 'launch' in plugin and plugin['launch']:
                         plugin_launch_file = find_resource(plugin['launch'])
                         rospy.loginfo(
                             "Launching plugin: {}".format(plugin_launch_file))

--- a/src/app_manager/app_manager.py
+++ b/src/app_manager/app_manager.py
@@ -265,13 +265,14 @@ class AppManager(object):
             if self._plugin_launch:
                 self._plugin_launch.start()
             if self._plugins:
+                ctx = {}
                 for plugin in self._plugins:
                     mod = __import__(plugin['module'].split('.')[0])
                     for sub_mod in plugin['module'].split('.')[1:]:
                         mod = getattr(mod, sub_mod)
                     start_plugin_attr = getattr(
                         mod, 'app_manager_start_plugin')
-                    start_plugin_attr(app)
+                    ctx = start_plugin_attr(app, ctx)
 
             # then launch main launch
             self._launch.start()
@@ -306,12 +307,14 @@ class AppManager(object):
                     "App stopped with exit code: {}".format(exit_code))
             # then stop plugin launch
             if self._plugin_launch:
+                ctx = {}
+                ctx['exit_code'] = exit_code
                 for plugin in self._plugins:
                     mod = __import__(plugin['module'].split('.')[0])
                     for sub_mod in plugin['module'].split('.')[1:]:
                         mod = getattr(mod, sub_mod)
                     stop_plugin_attr = getattr(mod, 'app_manager_stop_plugin')
-                    stop_plugin_attr(self._current_app_definition, exit_code)
+                    ctx = stop_plugin_attr(self._current_app_definition, ctx)
                 self._plugin_launch.shutdown()
                 if exit_code == 0:
                     rospy.loginfo(

--- a/src/app_manager/app_manager.py
+++ b/src/app_manager/app_manager.py
@@ -222,18 +222,19 @@ class AppManager(object):
             self._status_pub.publish(AppStatus(AppStatus.INFO, 'launching %s'%(app.display_name)))
 
             plugin_launch_files = []
-            for plugin in self._plugins:
-                plugin_launch_file = find_resource(plugin['launch'])
-                rospy.loginfo(
-                    "Launching plugin: {}".format(plugin_launch_file))
-                plugin_launch_files.append(plugin_launch_file)
+            if self._plugins:
+                for plugin in self._plugins:
+                    plugin_launch_file = find_resource(plugin['launch'])
+                    rospy.loginfo(
+                        "Launching plugin: {}".format(plugin_launch_file))
+                    plugin_launch_files.append(plugin_launch_file)
 
-            for plugin in self._plugins:
-                mod = __import__(plugin['module'].split('.')[0])
-                for sub_mod in plugin['module'].split('.')[1:]:
-                    mod = getattr(mod, sub_mod)
-                start_plugin_attr = getattr(mod, 'app_manager_start_plugin')
-                tart_plugin_attr(app)
+                for plugin in self._plugins:
+                    mod = __import__(plugin['module'].split('.')[0])
+                    for sub_mod in plugin['module'].split('.')[1:]:
+                        mod = getattr(mod, sub_mod)
+                    start_plugin_attr = getattr(mod, 'app_manager_start_plugin')
+                    start_plugin_attr(app)
 
             #TODO:XXX This is a roslaunch-caller-like abomination.  Should leverage a true roslaunch API when it exists.
             self._launch = roslaunch.parent.ROSLaunchParent(
@@ -286,12 +287,12 @@ class AppManager(object):
                     "App stopped with exit code: {}".format(exit_code))
             if self._plugin_launch:
                 self._plugin_launch.shutdown()
-            for plugin in self._plugins:
-                mod = __import__(plugin['module'].split('.')[0])
-                for sub_mod in plugin['module'].split('.')[1:]:
-                    mod = getattr(mod, sub_mod)
-                stop_plugin_attr = getattr(mod, 'app_manager_stop_plugin')
-                stop_plugin_attr(self._current_app_definition)
+                for plugin in self._plugins:
+                    mod = __import__(plugin['module'].split('.')[0])
+                    for sub_mod in plugin['module'].split('.')[1:]:
+                        mod = getattr(mod, sub_mod)
+                    stop_plugin_attr = getattr(mod, 'app_manager_stop_plugin')
+                    stop_plugin_attr(self._current_app_definition)
         finally:
             self._launch = None
             self._plugin_launch = None

--- a/src/app_manager/app_manager.py
+++ b/src/app_manager/app_manager.py
@@ -334,10 +334,11 @@ class AppManager(object):
                 self._plugin_context = {}
                 for app_plugin, plugin in self._current_plugins:
                     if 'module' in plugin and plugin['module']:
+                        plugin_args = {}
                         if 'plugin_args' in app_plugin:
-                            plugin_args = app_plugin['plugin_args']
-                        else:
-                            plugin_args = None
+                            plugin_args.update(app_plugin['plugin_args'])
+                        if 'start_plugin_args' in app_plugin:
+                            plugin_args.update(app_plugin['start_plugin_args'])
                         mod = __import__(plugin['module'].split('.')[0])
                         for sub_mod in plugin['module'].split('.')[1:]:
                             mod = getattr(mod, sub_mod)
@@ -402,10 +403,11 @@ class AppManager(object):
             self._plugin_context['exit_code'] = self._exit_code
             for app_plugin, plugin in self._current_plugins:
                 if 'module' in plugin and plugin['module']:
+                    plugin_args = {}
                     if 'plugin_args' in app_plugin:
-                        plugin_args = app_plugin['plugin_args']
-                    else:
-                        plugin_args = None
+                        plugin_args.update(app_plugin['plugin_args'])
+                    if 'stop_plugin_args' in app_plugin:
+                        plugin_args.update(app_plugin['stop_plugin_args'])
                     mod = __import__(plugin['module'].split('.')[0])
                     for sub_mod in plugin['module'].split('.')[1:]:
                         mod = getattr(mod, sub_mod)

--- a/src/app_manager/app_manager.py
+++ b/src/app_manager/app_manager.py
@@ -228,6 +228,13 @@ class AppManager(object):
                     "Launching plugin: {}".format(plugin_launch_file))
                 plugin_launch_files.append(plugin_launch_file)
 
+            for plugin in self._plugins:
+                mod = __import__(plugin['module'].split('.')[0])
+                for sub_mod in plugin['module'].split('.')[1:]:
+                    mod = getattr(mod, sub_mod)
+                start_plugin_attr = getattr(mod, 'app_manager_start_plugin')
+                start_plugin_attr()
+
             #TODO:XXX This is a roslaunch-caller-like abomination.  Should leverage a true roslaunch API when it exists.
             self._launch = roslaunch.parent.ROSLaunchParent(
                 rospy.get_param("/run_id"), [app.launch],
@@ -279,6 +286,12 @@ class AppManager(object):
                     "App stopped with exit code: {}".format(exit_code))
             if self._plugin_launch:
                 self._plugin_launch.shutdown()
+            for plugin in self._plugins:
+                mod = __import__(plugin['module'].split('.')[0])
+                for sub_mod in plugin['module'].split('.')[1:]:
+                    mod = getattr(mod, sub_mod)
+                stop_plugin_attr = getattr(mod, 'app_manager_stop_plugin')
+                stop_plugin_attr()
         finally:
             self._launch = None
             self._plugin_launch = None

--- a/src/app_manager/app_manager.py
+++ b/src/app_manager/app_manager.py
@@ -281,18 +281,25 @@ class AppManager(object):
     def _stop_current(self):
         try:
             self._launch.shutdown()
+            exit_code = 0
             if len(self._launch.pm.dead_list) > 0:
                 exit_code = self._launch.pm.dead_list[0].exit_code
                 rospy.logerr(
                     "App stopped with exit code: {}".format(exit_code))
             if self._plugin_launch:
                 self._plugin_launch.shutdown()
+                if exit_code == 0:
+                    rospy.loginfo(
+                        "Task stoped with exit code: {}".format(exit_code))
+                else:
+                    rospy.logerr(
+                        "Task stoped with exit code: {}".format(exit_code))
                 for plugin in self._plugins:
                     mod = __import__(plugin['module'].split('.')[0])
                     for sub_mod in plugin['module'].split('.')[1:]:
                         mod = getattr(mod, sub_mod)
                     stop_plugin_attr = getattr(mod, 'app_manager_stop_plugin')
-                    stop_plugin_attr(self._current_app_definition)
+                    stop_plugin_attr(self._current_app_definition, exit_code)
         finally:
             self._launch = None
             self._plugin_launch = None

--- a/src/app_manager/app_manager.py
+++ b/src/app_manager/app_manager.py
@@ -235,10 +235,11 @@ class AppManager(object):
             plugin_launch_files = []
             if self._plugins:
                 for plugin in self._plugins:
-                    plugin_launch_file = find_resource(plugin['launch'])
-                    rospy.loginfo(
-                        "Launching plugin: {}".format(plugin_launch_file))
-                    plugin_launch_files.append(plugin_launch_file)
+                    if plugin['launch']:
+                        plugin_launch_file = find_resource(plugin['launch'])
+                        rospy.loginfo(
+                            "Launching plugin: {}".format(plugin_launch_file))
+                        plugin_launch_files.append(plugin_launch_file)
 
             #TODO:XXX This is a roslaunch-caller-like abomination.  Should leverage a true roslaunch API when it exists.
             self._launch = roslaunch.parent.ROSLaunchParent(

--- a/src/app_manager/app_manager.py
+++ b/src/app_manager/app_manager.py
@@ -36,6 +36,7 @@
 
 import thread
 import time
+import yaml
 
 import rosgraph.names
 import rospy
@@ -335,10 +336,28 @@ class AppManager(object):
                 for app_plugin, plugin in self._current_plugins:
                     if 'module' in plugin and plugin['module']:
                         plugin_args = {}
+                        start_plugin_args = {}
                         if 'plugin_args' in app_plugin:
                             plugin_args.update(app_plugin['plugin_args'])
+                        if 'plugin_arg_yaml' in app_plugin:
+                            with open(app_plugin['plugin_arg_yaml']) as yaml_f:
+                                yaml_plugin_args = yaml.load(yaml_f)
+                            for k, v in yaml_plugin_args.items():
+                                if k in plugin_args:
+                                    rospy.logwarn("'{}' is set both in plugin_args and plugin_arg_yaml".format(k))
+                                    rospy.logwarn("'{}' is overwritten: {} -> {}".format(k, plugin_args[k], v))
+                                plugin_args[k] = v
                         if 'start_plugin_args' in app_plugin:
-                            plugin_args.update(app_plugin['start_plugin_args'])
+                            start_plugin_args.update(app_plugin['start_plugin_args'])
+                        if 'start_plugin_arg_yaml' in app_plugin:
+                            with open(app_plugin['start_plugin_arg_yaml']) as yaml_f:
+                                yaml_plugin_args = yaml.load(yaml_f)
+                            for k, v in yaml_plugin_args.items():
+                                if k in start_plugin_args:
+                                    rospy.logwarn("'{}' is set both in start_plugin_args and start_plugin_arg_yaml".format(k))
+                                    rospy.logwarn("'{}' is overwritten: {} -> {}".format(k, start_plugin_args[k], v))
+                                start_plugin_args[k] = v
+                        plugin_args.update(start_plugin_args)
                         mod = __import__(plugin['module'].split('.')[0])
                         for sub_mod in plugin['module'].split('.')[1:]:
                             mod = getattr(mod, sub_mod)
@@ -404,10 +423,28 @@ class AppManager(object):
             for app_plugin, plugin in self._current_plugins:
                 if 'module' in plugin and plugin['module']:
                     plugin_args = {}
+                    stop_plugin_args = {}
                     if 'plugin_args' in app_plugin:
                         plugin_args.update(app_plugin['plugin_args'])
+                    if 'plugin_arg_yaml' in app_plugin:
+                        with open(app_plugin['plugin_arg_yaml']) as yaml_f:
+                            yaml_plugin_args = yaml.load(yaml_f)
+                        for k, v in yaml_plugin_args.items():
+                            if k in plugin_args:
+                                rospy.logwarn("'{}' is set both in plugin_args and plugin_arg_yaml".format(k))
+                                rospy.logwarn("'{}' is overwritten: {} -> {}".format(k, plugin_args[k], v))
+                            plugin_args[k] = v
                     if 'stop_plugin_args' in app_plugin:
-                        plugin_args.update(app_plugin['stop_plugin_args'])
+                        stop_plugin_args.update(app_plugin['stop_plugin_args'])
+                    if 'stop_plugin_arg_yaml' in app_plugin:
+                        with open(app_plugin['stop_plugin_arg_yaml']) as yaml_f:
+                            yaml_plugin_args = yaml.load(yaml_f)
+                        for k, v in yaml_plugin_args.items():
+                            if k in stop_plugin_args:
+                                rospy.logwarn("'{}' is set both in stop_plugin_args and stop_plugin_arg_yaml".format(k))
+                                rospy.logwarn("'{}' is overwritten: {} -> {}".format(k, stop_plugin_args[k], v))
+                            stop_plugin_args[k] = v
+                    plugin_args.update(stop_plugin_args)
                     mod = __import__(plugin['module'].split('.')[0])
                     for sub_mod in plugin['module'].split('.')[1:]:
                         mod = getattr(mod, sub_mod)

--- a/src/app_manager/app_manager.py
+++ b/src/app_manager/app_manager.py
@@ -329,9 +329,7 @@ class AppManager(object):
                 for t in app.interface.subscribed_topics.keys():
                     N.remap_args.append((t, self._app_interface + '/' + t))
 
-            # run plugin launches first
-            if self._plugin_launch:
-                self._plugin_launch.start()
+            # run plugin modules first
             if self._current_plugins:
                 self._plugin_context = {}
                 for app_plugin, plugin in self._current_plugins:
@@ -347,8 +345,11 @@ class AppManager(object):
                             mod, 'app_manager_start_plugin')
                         self._plugin_context = start_plugin_attr(
                             app, self._plugin_context, plugin_args)
+            # then, start plugin launches
+            if self._plugin_launch:
+                self._plugin_launch.start()
 
-            # then launch main launch
+            # finally launch main launch
             self._launch.start()
 
             fp = [self._app_interface + '/' + x for x in app.interface.subscribed_topics.keys()]

--- a/src/app_manager/app_manager.py
+++ b/src/app_manager/app_manager.py
@@ -332,17 +332,18 @@ class AppManager(object):
             if self._current_plugins:
                 self._plugin_context = {}
                 for app_plugin, plugin in self._current_plugins:
-                    if 'plugin_args' in app_plugin:
-                        plugin_args = app_plugin['plugin_args']
-                    else:
-                        plugin_args = None
-                    mod = __import__(plugin['module'].split('.')[0])
-                    for sub_mod in plugin['module'].split('.')[1:]:
-                        mod = getattr(mod, sub_mod)
-                    start_plugin_attr = getattr(
-                        mod, 'app_manager_start_plugin')
-                    self._plugin_context = start_plugin_attr(
-                        app, self._plugin_context, plugin_args)
+                    if 'module' in plugin and plugin['module']:
+                        if 'plugin_args' in app_plugin:
+                            plugin_args = app_plugin['plugin_args']
+                        else:
+                            plugin_args = None
+                        mod = __import__(plugin['module'].split('.')[0])
+                        for sub_mod in plugin['module'].split('.')[1:]:
+                            mod = getattr(mod, sub_mod)
+                        start_plugin_attr = getattr(
+                            mod, 'app_manager_start_plugin')
+                        self._plugin_context = start_plugin_attr(
+                            app, self._plugin_context, plugin_args)
 
             # then launch main launch
             self._launch.start()
@@ -396,17 +397,18 @@ class AppManager(object):
         if self._current_plugins:
             self._plugin_context['exit_code'] = self._exit_code
             for app_plugin, plugin in self._current_plugins:
-                if 'plugin_args' in app_plugin:
-                    plugin_args = app_plugin['plugin_args']
-                else:
-                    plugin_args = None
-                mod = __import__(plugin['module'].split('.')[0])
-                for sub_mod in plugin['module'].split('.')[1:]:
-                    mod = getattr(mod, sub_mod)
-                stop_plugin_attr = getattr(mod, 'app_manager_stop_plugin')
-                self._plugin_context = stop_plugin_attr(
-                    self._current_app_definition,
-                    self._plugin_context, plugin_args)
+                if 'module' in plugin and plugin['module']:
+                    if 'plugin_args' in app_plugin:
+                        plugin_args = app_plugin['plugin_args']
+                    else:
+                        plugin_args = None
+                    mod = __import__(plugin['module'].split('.')[0])
+                    for sub_mod in plugin['module'].split('.')[1:]:
+                        mod = getattr(mod, sub_mod)
+                    stop_plugin_attr = getattr(mod, 'app_manager_stop_plugin')
+                    self._plugin_context = stop_plugin_attr(
+                        self._current_app_definition,
+                        self._plugin_context, plugin_args)
 
     def handle_stop_app(self, req):
         rospy.loginfo("handle stop app: %s"%(req.name))

--- a/src/app_manager/app_manager.py
+++ b/src/app_manager/app_manager.py
@@ -34,7 +34,6 @@
 
 # author: leibs
 
-import logging
 import thread
 import time
 
@@ -61,8 +60,6 @@ def _load_config_default(
         roslaunch_files, port, roslaunch_strs=None, loader=None, verbose=False,
         assign_machines=True, ignore_unset_args=False
 ):
-    logger = logging.getLogger('roslaunch.config')
-
     config = roslaunch.config.ROSLaunchConfig()
     if port:
         config.master.uri = rosgraph.network.create_local_xmlrpc_uri(port)
@@ -82,7 +79,7 @@ def _load_config_default(
         else:
             args = None
         try:
-            logger.info('loading config file %s' % f)
+            rospy.loginfo('loading config file %s' % f)
             loader.load(f, config, argv=args, verbose=verbose)
         except roslaunch.xmlloader.XmlParseException as e:
             raise roslaunch.core.RLException(e)
@@ -93,7 +90,7 @@ def _load_config_default(
     if roslaunch_strs:
         for launch_str in roslaunch_strs:
             try:
-                logger.info('loading config file from string')
+                rospy.loginfo('loading config file from string')
                 loader.load_string(launch_str, config)
             except roslaunch.xmlloader.XmlParseException as e:
                 raise roslaunch.core.RLException(

--- a/src/app_manager/app_manager.py
+++ b/src/app_manager/app_manager.py
@@ -244,15 +244,23 @@ class AppManager(object):
             plugin_launch_files = []
             if self._plugins:
                 self._current_plugins = []
-                for p in app.plugins:
-                    p_type = p['type']
-                    plugin = [p for p in self._plugins if p['name'] == p_type][0]
+                for app_plugin in app.plugins:
+                    app_plugin_type = app_plugin['type']
+                    plugin = [p for p in self._plugins if p['name'] == app_plugin_type][0]
                     self._current_plugins.append(plugin)
                     if 'launch' in plugin and plugin['launch']:
                         plugin_launch_file = find_resource(plugin['launch'])
+                        if 'launch_args' in app_plugin:
+                            plugin_launch_args = []
+                            for k, v in app_plugin['launch_args'].items():
+                                plugin_launch_args.append('{}:={}'.format(k, v))
+                        else:
+                            plugin_launch_args = None
                         rospy.loginfo(
-                            "Launching plugin: {}".format(plugin_launch_file))
-                        plugin_launch_files.append(plugin_launch_file)
+                            "Launching plugin: {} {}".format(
+                                plugin_launch_file, plugin_launch_args))
+                        plugin_launch_files.append(
+                            (plugin_launch_file, plugin_launch_args))
 
             #TODO:XXX This is a roslaunch-caller-like abomination.  Should leverage a true roslaunch API when it exists.
             self._launch = roslaunch.parent.ROSLaunchParent(

--- a/src/app_manager/app_manager.py
+++ b/src/app_manager/app_manager.py
@@ -233,7 +233,7 @@ class AppManager(object):
                 for sub_mod in plugin['module'].split('.')[1:]:
                     mod = getattr(mod, sub_mod)
                 start_plugin_attr = getattr(mod, 'app_manager_start_plugin')
-                start_plugin_attr()
+                tart_plugin_attr(app)
 
             #TODO:XXX This is a roslaunch-caller-like abomination.  Should leverage a true roslaunch API when it exists.
             self._launch = roslaunch.parent.ROSLaunchParent(
@@ -291,7 +291,7 @@ class AppManager(object):
                 for sub_mod in plugin['module'].split('.')[1:]:
                     mod = getattr(mod, sub_mod)
                 stop_plugin_attr = getattr(mod, 'app_manager_stop_plugin')
-                stop_plugin_attr()
+                stop_plugin_attr(self._current_app_definition)
         finally:
             self._launch = None
             self._plugin_launch = None

--- a/src/app_manager/app_manager.py
+++ b/src/app_manager/app_manager.py
@@ -119,12 +119,10 @@ class AppManager(object):
         if self._launch:
             self._launch.shutdown()
             self._interface_sync.stop()
-            if self._exit_code > 0:
-                rospy.logerr(
-                    "App stopped with exit code: {}".format(self._exit_code))
-            elif (self._exit_code is None
+            if (self._exit_code is None
                     and len(self._launch.pm.dead_list) > 0):
                 self._exit_code = self._launch.pm.dead_list[0].exit_code
+            if self._exit_code > 0:
                 rospy.logerr(
                     "App stopped with exit code: {}".format(self._exit_code))
         if self._plugin_launch:
@@ -330,12 +328,10 @@ class AppManager(object):
         try:
             # stop main launch first
             self._launch.shutdown()
-            if self._exit_code > 0:
-                rospy.logerr(
-                    "App stopped with exit code: {}".format(self._exit_code))
-            elif (self._exit_code is None
+            if (self._exit_code is None
                     and len(self._launch.pm.dead_list) > 0):
                 self._exit_code = self._launch.pm.dead_list[0].exit_code
+            if self._exit_code > 0:
                 rospy.logerr(
                     "App stopped with exit code: {}".format(self._exit_code))
             # then stop plugin launch

--- a/src/app_manager/app_manager.py
+++ b/src/app_manager/app_manager.py
@@ -127,6 +127,8 @@ class AppManager(object):
                 self._exit_code = self._launch.pm.dead_list[0].exit_code
                 rospy.logerr(
                     "App stopped with exit code: {}".format(self._exit_code))
+        if self._plugin_launch:
+            self._plugin_launch.shutdown()
         if self._current_plugins:
             self._plugin_context['exit_code'] = self._exit_code
             for app_plugin, plugin in self._current_plugins:
@@ -141,9 +143,6 @@ class AppManager(object):
                 self._plugin_context = stop_plugin_attr(
                     self._current_app_definition,
                     self._plugin_context, plugin_args)
-        if self._plugin_launch:
-            self._plugin_launch.shutdown()
-
     def _get_current_app(self):
         return self._current_app
 
@@ -340,6 +339,8 @@ class AppManager(object):
                 rospy.logerr(
                     "App stopped with exit code: {}".format(self._exit_code))
             # then stop plugin launch
+            if self._plugin_launch:
+                self._plugin_launch.shutdown()
             if self._current_plugins:
                 self._plugin_context['exit_code'] = self._exit_code
                 for app_plugin, plugin in self._current_plugins:
@@ -354,8 +355,6 @@ class AppManager(object):
                     self._plugin_context = stop_plugin_attr(
                         self._current_app_definition,
                         self._plugin_context, plugin_args)
-            if self._plugin_launch:
-                self._plugin_launch.shutdown()
         finally:
             self._launch = None
             self._plugin_launch = None

--- a/src/app_manager/app_manager.py
+++ b/src/app_manager/app_manager.py
@@ -255,6 +255,8 @@ class AppManager(object):
                         if 'launch_args' in app_plugin:
                             plugin_launch_args = []
                             for k, v in app_plugin['launch_args'].items():
+                                if isinstance(v, list):
+                                    v = " ".join(map(str, v))
                                 plugin_launch_args.append("{}:={}".format(k, v))
                         else:
                             plugin_launch_args = None

--- a/src/app_manager/app_manager.py
+++ b/src/app_manager/app_manager.py
@@ -257,7 +257,7 @@ class AppManager(object):
                         if 'launch_args' in app_plugin:
                             plugin_launch_args = []
                             for k, v in app_plugin['launch_args'].items():
-                                plugin_launch_args.append('{}:={}'.format(k, v))
+                                plugin_launch_args.append("{}:={}".format(k, v))
                         else:
                             plugin_launch_args = None
                         rospy.loginfo(

--- a/src/app_manager/app_manager.py
+++ b/src/app_manager/app_manager.py
@@ -122,7 +122,8 @@ class AppManager(object):
             if self._exit_code > 0:
                 rospy.logerr(
                     "App stopped with exit code: {}".format(self._exit_code))
-            elif len(self._launch.pm.dead_list) > 0:
+            elif (self._exit_code is None
+                    and len(self._launch.pm.dead_list) > 0):
                 self._exit_code = self._launch.pm.dead_list[0].exit_code
                 rospy.logerr(
                     "App stopped with exit code: {}".format(self._exit_code))
@@ -316,7 +317,8 @@ class AppManager(object):
             if self._exit_code > 0:
                 rospy.logerr(
                     "App stopped with exit code: {}".format(self._exit_code))
-            elif len(self._launch.pm.dead_list) > 0:
+            elif (self._exit_code is None
+                    and len(self._launch.pm.dead_list) > 0):
                 self._exit_code = self._launch.pm.dead_list[0].exit_code
                 rospy.logerr(
                     "App stopped with exit code: {}".format(self._exit_code))
@@ -366,13 +368,10 @@ class AppManager(object):
                 if pm:
                     procs = pm.procs[:]
                     if len(procs) > 0:
-                        required = [p.required for p in procs]
-                        if any(required):
+                        if any([p.required for p in procs]):
                             exit_codes = [
                                 p.exit_code for p in procs if p.required]
-                        else:
-                            exit_codes = [p.exit_code for p in procs]
-                        self._exit_code = max(exit_codes)
+                            self._exit_code = max(exit_codes)
                     if pm.done:
                         time.sleep(1.0)
                         self.stop_app(self._current_app_definition.name)

--- a/src/app_manager/app_manager_plugin.py
+++ b/src/app_manager/app_manager_plugin.py
@@ -1,0 +1,65 @@
+class AppManagerPlugin(object):
+
+    """Base class for app_manager plugin
+
+    This is a base class for app_manager plugin.
+    app_manager plugin have two class methods;
+    app_manager_start_plugin and app_manager_stop_plugin.
+    app_manager_start_plugin runs before app starts,
+    and app_manager_stop_plugin runs after app stops.
+
+    app_manager plugin is defined in yaml format as below;
+    - name: app_recorder/rosbag_recorder_plugin  # plugin name
+      launch: app_recorder/rosbag_recorder.launch  # plugin launch name
+      module: app_recorder.rosbag_recorder_plugin.RosbagRecorderPlugin
+      # plugin module name
+
+    Also, app_manager plugin yaml file is exported in package.xml as below;
+     <export>
+       <app_manager plugin="${prefix}/app_recorder_plugin.yaml" />
+     </export>
+
+    In app file, you can add plugin to your app as below;
+    - plugins
+      - name: mail_notifier_plugin  # name to identify this plugin
+        type: app_notifier/mail_notifier_plugin  # plugin type
+        launch_args:  # arguments for plugin launch file
+          - foo: bar
+        plugin_args:  # arguments for plugin function arguments
+          - hoge: fuga
+
+    Both class methods have 3 arguments;
+    App definition, app context and app plugin arguments.
+    App definition is the definition of app.
+    App context is the shared information about app (app context)
+    between plugins, such as app results and plugin results.
+    App plugin arguments are the arguments for the module defined in app file
+    and written as below;
+    """
+
+    def __init__(self):
+        pass
+
+    @classmethod
+    def app_manager_start_plugin(cls, app, ctx, plugin_args):
+        """Start plugin for app_manager
+
+        Args:
+            app (app_manager.AppDefinition): app definition
+            ctx (dict): app context shared between plugins
+            plugin_args (dict): arguments for plugin defined in app file
+        """
+
+        return ctx
+
+    @classmethod
+    def app_manager_stop_plugin(cls, app, ctx, plugin_args):
+        """Stop plugin for app_manager
+
+        Args:
+            app (app_manager.AppDefinition): app definition
+            ctx (dict): app context shared between plugins
+            plugin_args (dict): arguments for plugin defined in app file
+        """
+
+        return ctx


### PR DESCRIPTION
# Adding app manager plugin

## Note

~~this plugin depends on `roslaunch>=1.13.6` https://github.com/ros/ros_comm/pull/1115~~
UPDATE: I overwrite required function for kinetic users in cb23aae660bbe9d3b50f70ceb83ecfcd48672f54

## Description
Now, I'm planning to add plugins for app_manager.
This is because I want to use app information and result before and after the app.
This PR is draft and proposal for app_manager plugins, and I made app_manager plugin examples in https://github.com/knorth55/app_manager_utils.
I made these plugins below for apps.
- data recorder plugin
  - video recorder plugin: record image during an app
  - rosbag recorder plugin: record rosbag during an app
- data uploader plugin
  - google drive uploader plugin: upload recorded data in google drive
- notifier plugin
  - mail notifier: mail app results and uploaded data url

## How to make new plugin

### Add launch

First, we can set launch file for plugin as normal launch as belows.

```xml
<launch>
  <!-- launch_args: arguments for plugin launch -->
  <arg name="foo" />
  <!-- add some nodes  -->
  <node name="$(anon rosbag_recorder)" pkg="rosbag" type="record" args="/tf /joint_states" />
</launch>
```

### Add plugin module

Then, we need to set plugin function as follows.

```python
class RosbagRecorderPlugin(object):
    # app_manager plugin function before app
    # app: app definition
    # ctx: app context which is shared through all plugins
    # plugin_args: plugin arguments defined in app file
    @classmethod
    def app_manager_start_plugin(cls, app, ctx, plugin_args):
        # do something before app runs
        return ctx

    # app_manager plugin function after app
    # app: app definition
    # ctx: app context which is shared through all plugins
    # plugin_args: plugin arguments defined in app file
    @classmethod
    def app_manager_stop_plugin(cls, app, ctx, plugin_args):
        # do something after app runs
        return ctx
```

### Add plugin yaml

Next, we need to add plugin config yaml file as follows.
```yaml
- name: app_recorder/rosbag_recorder_plugin  # plugin name
  launch: app_recorder/rosbag_recorder.launch  # plugin launch name
  module: app_recorder.rosbag_recorder_plugin.RosbagRecorderPlugin  # plugin module name
```

In `package.xml`, we need to set yaml file path then as follows.
```xml
  <export>
    <app_manager plugin="${prefix}/app_recorder_plugin.yaml" />
  </export>
```

## How to enable plugin in an app

In order to enable plugins, we need to write plugins in app file (i.e. `test_app.app`) as follows.

```yaml
plugins: # plugin definitions
  - name: mail_notifier_plugin  # name to identify this plugin
    type: app_notifier/mail_notifier_plugin  # plugin type
    launch_args:  # arguments for plugin launch file
      - foo: hello
    launch_arg_yaml: /etc/mail_notifier_launch_arg.yaml  # argument yaml file for plugin launch file
    # in this case, these arguments will be passed.
    # {"hoge": 100, "fuga": 30, "bar": 10} will be passed to start plugin
    # {"hoge": 50, "fuga": 30} will be passed to stop plugin
    plugin_args:  # arguments for plugin function
      - hoge: 10
      - fuga: 30
    start_plugin_args:  # arguments for start plugin function
      - hoge: 100  # arguments for start plugin function arguments (it overwrites plugin_args hoge: 10 -> 100)
      - bar: 10
    stop_plugin_args:  # arguments for stop plugin function
      - hoge: 50  # arguments for stop plugin function arguments (it overwrites plugin_args hoge: 10 -> 50)
    plugin_arg_yaml: /etc/mail_notifier_plugin_arg.yaml  # argument yaml file for plugin function arguments
  - name: rosbag_recorder_plugin  # another plugin
    type app_recorder/rosbag_recorder_plugin
    launch_args:
      rosbag_path: /tmp
      rosbag_title: test.bag
      compress: true
      rosbag_topic_names:
        - /rosout
        - /tf
        - /tf_static
plugin_order: # plugin running orders. if you don't set field, plugin will be run in order in plugins field
  start_plugin_order:  # start plugin running order
    - rosbag_recorder_plugin  # 1st plugin name
    - mail_notifier_plugin  #2nd plugin name
  stop_plugin_order:  # start plugin running order
    - rosbag_recorder_plugin
    - mail_notifier_plugin
```