### PR TITLE
add enable_app_replacement param in app_manager

### DIFF
--- a/scripts/app_manager
+++ b/scripts/app_manager
@@ -91,8 +91,11 @@ def main():
             rospy.logerr("Failed to load exchange: {}".format(e))
             sys.exit(1)
 
+    enable_overwrite = rospy.get_param('~enable_overwrite', True)
+
     am = app_manager.AppManager(
-        robot_name, interface_master, app_list, exchange, plugins)
+        robot_name, interface_master, app_list, exchange, plugins,
+        enable_overwrite=enable_overwrite)
 
     rospy.on_shutdown(am.shutdown)
 

--- a/scripts/app_manager
+++ b/scripts/app_manager
@@ -91,11 +91,11 @@ def main():
             rospy.logerr("Failed to load exchange: {}".format(e))
             sys.exit(1)
 
-    enable_overwrite = rospy.get_param('~enable_overwrite', True)
+    enable_app_replacement = rospy.get_param('~enable_app_replacement', True)
 
     am = app_manager.AppManager(
         robot_name, interface_master, app_list, exchange, plugins,
-        enable_overwrite=enable_overwrite)
+        enable_app_replacement=enable_app_replacement)
 
     rospy.on_shutdown(am.shutdown)
 

--- a/src/app_manager/app_manager.py
+++ b/src/app_manager/app_manager.py
@@ -119,7 +119,7 @@ class AppManager(object):
 
     def __init__(
             self, robot_name, interface_master, app_list,
-            exchange, plugins=None
+            exchange, plugins=None, enable_overwrite=True,
     ):
         self._robot_name = robot_name
         self._interface_master = interface_master
@@ -127,6 +127,7 @@ class AppManager(object):
         self._current_app = self._current_app_definition = None
         self._exchange = exchange
         self._plugins = plugins
+        self._enable_overwrite = enable_overwrite
             
         rospy.loginfo("Starting app manager for %s"%self._robot_name)
 
@@ -263,6 +264,13 @@ class AppManager(object):
         if self._current_app:
             if self._current_app_definition.name == req.name:
                 return StartAppResponse(started=True, message="app [%s] already started"%(req.name), namespace=self._app_interface)
+            elif not self._enable_overwrite:
+                return StartAppResponse(
+                    started=False,
+                    message="app [%s] is denied because app [%s] is already running."
+                            % (req.name, self._current_app_definition.name),
+                    namespace=self._app_interface,
+                    error_code=StatusCodes.MULTIAPP_NOT_SUPPORTED)
             else:
                 self.stop_app(self._current_app_definition.name)
             #return StartAppResponse(started=False, message="Please stop the running app before starting another app.", error_code=StatusCodes.MULTIAPP_NOT_SUPPORTED)

--- a/src/app_manager/app_manager.py
+++ b/src/app_manager/app_manager.py
@@ -119,7 +119,7 @@ class AppManager(object):
 
     def __init__(
             self, robot_name, interface_master, app_list,
-            exchange, plugins=None, enable_overwrite=True,
+            exchange, plugins=None, enable_app_replacement=True,
     ):
         self._robot_name = robot_name
         self._interface_master = interface_master
@@ -127,7 +127,7 @@ class AppManager(object):
         self._current_app = self._current_app_definition = None
         self._exchange = exchange
         self._plugins = plugins
-        self._enable_overwrite = enable_overwrite
+        self._enable_app_replacement = enable_app_replacement
             
         rospy.loginfo("Starting app manager for %s"%self._robot_name)
 
@@ -264,7 +264,7 @@ class AppManager(object):
         if self._current_app:
             if self._current_app_definition.name == req.name:
                 return StartAppResponse(started=True, message="app [%s] already started"%(req.name), namespace=self._app_interface)
-            elif not self._enable_overwrite:
+            elif not self._enable_app_replacement:
                 return StartAppResponse(
                     started=False,
                     message="app [%s] is denied because app [%s] is already running."

--- a/src/app_manager/app_manager.py
+++ b/src/app_manager/app_manager.py
@@ -273,7 +273,6 @@ class AppManager(object):
                     error_code=StatusCodes.MULTIAPP_NOT_SUPPORTED)
             else:
                 self.stop_app(self._current_app_definition.name)
-            #return StartAppResponse(started=False, message="Please stop the running app before starting another app.", error_code=StatusCodes.MULTIAPP_NOT_SUPPORTED)
 
         # TODO: the app list has already loaded the App data.  We should use that instead for consistency
 


### PR DESCRIPTION
I add `enable_app_replacement` parameter in `app_manager`.
This parameter enable us to control whether `app_manager` denies overwriting app or not.
In the following example, I set `enable_app_replacement` `false`, and `app_manager` denied `go_to_kitchen` app because `time_signal` app is still running.

```bash
fetch@fetch15:~/ros/indigo/src/jsk-ros-pkg/jsk_robot$ rosservice call /fetch15/start_app "name: 'jsk_fetch_startup/time_signal'" 
started: True
error_code: 0
message: app [jsk_fetch_startup/time_signal] started
namespace: /fetch15/application
fetch@fetch15:~/ros/indigo/src/jsk-ros-pkg/jsk_robot$ rosservice call /fetch15/start_app "name: 'jsk_fetch_startup/go_to_kitchen'" 
started: False
error_code: 511
message: app [jsk_fetch_startup/go_to_kitchen] is denied because app [jsk_fetch_startup/time_signal] is already running.
namespace: /fetch15/application
fetch@fetch15:~/ros/indigo/src/jsk-ros-pkg/jsk_robot$ 

```

cc. @k-okada 