### PR TITLE
add arguments in StartAppRequest

### DIFF
--- a/src/app_manager/app_manager.py
+++ b/src/app_manager/app_manager.py
@@ -290,8 +290,17 @@ class AppManager(object):
         try:
             self._set_current_app(App(name=appname), app)
 
-            rospy.loginfo("Launching: %s"%(app.launch))
             self._status_pub.publish(AppStatus(AppStatus.INFO, 'launching %s'%(app.display_name)))
+
+            if len(req.args) == 0:
+                launch_files = [app.launch]
+                rospy.loginfo("Launching: {}".format(app.launch))
+            else:
+                app_launch_args = []
+                for arg in req.args:
+                    app_launch_args.append("{}:={}".format(arg.key, arg.value))
+                launch_files = [(app.launch, app_launch_args)]
+                rospy.loginfo("Launching: {} {}".format(app.launch, app_launch_args))
 
             plugin_launch_files = []
             if app.plugins:
@@ -348,7 +357,7 @@ class AppManager(object):
 
             #TODO:XXX This is a roslaunch-caller-like abomination.  Should leverage a true roslaunch API when it exists.
             self._launch = roslaunch.parent.ROSLaunchParent(
-                rospy.get_param("/run_id"), [app.launch],
+                rospy.get_param("/run_id"), launch_files,
                 is_core=False, process_listeners=())
             if len(plugin_launch_files) > 0:
                 self._plugin_launch = roslaunch.parent.ROSLaunchParent(

--- a/srv/StartApp.srv
+++ b/srv/StartApp.srv
@@ -1,5 +1,6 @@
 # Name of the app to launch
 string name 
+KeyValue[] args
 ---
 # true if app started, false otherwise
 bool started


### PR DESCRIPTION
UPDATED:

I want to add arguments in StartAppRequest service.
in this PR, I use `app_manager/KeyValue` message to pass arguments.
```bash
$ rossrv show app_manager/StartApp
string name
app_manager/KeyValue[] args
  string key
  string value
---
bool started
int32 error_code
string message
string namespace
```