### PR TITLE
add stopped context in app_manager plugin

### DIFF
--- a/src/app_manager/app_manager.py
+++ b/src/app_manager/app_manager.py
@@ -166,6 +166,7 @@ class AppManager(object):
         self._plugin_launch = None
         self._interface_sync = None
         self._exit_code = None
+        self._stopped = None
         self._current_plugins = None
         self._plugin_context = None
 
@@ -183,6 +184,7 @@ class AppManager(object):
             self._api_sync.stop()
         if self._interface_sync:
             self._interface_sync.stop()
+        self._stopped = True
         self.__stop_current()
 
     def _get_current_app(self):
@@ -434,6 +436,7 @@ class AppManager(object):
             self._launch = None
             self._plugin_launch = None
             self._exit_code = None
+            self._stopped = None
             self._current_plugins = None
             self._plugin_context = None
         try:
@@ -456,6 +459,7 @@ class AppManager(object):
             self._plugin_launch.shutdown()
         if self._current_plugins:
             self._plugin_context['exit_code'] = self._exit_code
+            self._plugin_context['stopped'] = self._stopped
             if 'stop_plugin_order' in self._current_app_definition.plugin_order:
                 plugin_names = [p['name'] for p in self._current_app_definition.plugins]
                 plugin_order = self._current_app_definition.plugin_order['stop_plugin_order']
@@ -511,6 +515,7 @@ class AppManager(object):
 
     def handle_stop_app(self, req):
         rospy.loginfo("handle stop app: %s"%(req.name))
+        self._stopped = True
         return self.stop_app(req.name)
 
     def handle_reload_app_list(self, req=None):


### PR DESCRIPTION
I add `stopped` in plugin context.
This `stopped` indicates whether app is stopped by `stop_app` rosservice or not.