### PR TITLE
add available_apps in all platform apps

### DIFF
--- a/src/app_manager/app_list.py
+++ b/src/app_manager/app_list.py
@@ -129,9 +129,11 @@ class InstalledFile(object):
             self._file_mtime = s.st_mtime
 
     def get_available_apps(self, platform=None):
-        if (platform is not None and platform != 'all'):
-            return filter(lambda app: app.platform == platform,
-                          self.available_apps)
+        if platform is not None:
+            available_apps = filter(
+                lambda app: app.platform in [platform, 'all'],
+                self.available_apps)
+            return available_apps
         else:
             return self.available_apps
 


### PR DESCRIPTION
Fixed PR of #17 
I totally made wrong PR.
with this PR, we can add apps with `platform: all`, which all robots can run.