### PR TITLE
set stopped true in app timeout

### DIFF
--- a/src/app_manager/app_manager.py
+++ b/src/app_manager/app_manager.py
@@ -555,6 +555,7 @@ class AppManager(object):
                 if (timeout is not None and
                         self._start_time is not None and
                         (now - self._start_time).to_sec() > timeout):
+                    self._stopped = True
                     self.stop_app(appname)
                     rospy.logerr(
                         'app {} is stopped because of timeout: {}s'.format(


### PR DESCRIPTION
when app is `timeout`, `stopped` param in `plugin_context` is not set as `True`.
This PR correctly set `stopped` param as `True` when app is timeout in `plugin_context`.