### PR TITLE
use plugins as instance

### DIFF
--- a/src/app_manager/app_manager_plugin.py
+++ b/src/app_manager/app_manager_plugin.py
@@ -40,8 +40,7 @@ class AppManagerPlugin(object):
     def __init__(self):
         pass
 
-    @classmethod
-    def app_manager_start_plugin(cls, app, ctx, plugin_args):
+    def app_manager_start_plugin(self, app, ctx, plugin_args):
         """Start plugin for app_manager
 
         Args:
@@ -52,8 +51,7 @@ class AppManagerPlugin(object):
 
         return ctx
 
-    @classmethod
-    def app_manager_stop_plugin(cls, app, ctx, plugin_args):
+    def app_manager_stop_plugin(self, app, ctx, plugin_args):
         """Stop plugin for app_manager
 
         Args:


### PR DESCRIPTION
this PR changes to use `plugins` as `instance`.
previously, only `classmethod` is required, but we can use normal method with this PR.
this PR also enables us to share the same attributes in `app_manager_start_plugin` and `app_manager_stop_plugin`.
(for example, measuring the task time with `self.start_time = rospy.Time.now()`