### PR TITLE
do not run stop_app when _stopping is true

### DIFF
--- a/src/app_manager/app_manager.py
+++ b/src/app_manager/app_manager.py
@@ -167,6 +167,7 @@ class AppManager(object):
         self._interface_sync = None
         self._exit_code = None
         self._stopped = None
+        self._stopping = None
         self._current_plugins = None
         self._plugin_context = None
         self._plugin_insts = None
@@ -436,12 +437,14 @@ class AppManager(object):
     
     def _stop_current(self):
         try:
+            self._stopping = True
             self.__stop_current()
         finally:
             self._launch = None
             self._plugin_launch = None
             self._exit_code = None
             self._stopped = None
+            self._stopping = None
             self._current_plugins = None
             self._plugin_context = None
             self._plugin_insts = None
@@ -556,7 +559,8 @@ class AppManager(object):
                             self._exit_code = max(exit_codes)
                     if pm.done:
                         time.sleep(1.0)
-                        self.stop_app(appname)
+                        if not self._stopping:
+                            self.stop_app(appname)
                         break
                 if (timeout is not None and
                         self._start_time is not None and


### PR DESCRIPTION
when `stop_app` service is called, `stop_app` can be called twice from `stop_app` service and `app_monitor`.
this PR add `_stopping` attribute, and do not run `stop_app` from `app_monitor` when `_stopping` is true.