### PR TITLE
add test to check if we forget catkin_install_python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,10 @@ install:
   - (cd /tmp/ros_buildfarm; patch -p1 < /tmp/890.diff)
   - (cd /tmp/ros_buildfarm; sed -i "/# After all dependencies are installed, update ccache symlinks./a @[if testing]@\nRUN rosdep init\n@[end if]@\n" ros_buildfarm/templates/devel/devel_task.Dockerfile.em)
   - (cd /tmp/ros_buildfarm; sed -i "/USER buildfarm/a @[if testing]@\nRUN rosdep update\n@[end if]@\n" ros_buildfarm/templates/devel/devel_task.Dockerfile.em)
-  - (mkdir -p $JOB_PATH; cp -r /tmp/ros_buildfarm $JOB_PATH)
+  # revert https://github.com/ros/ros_comm/pull/1879, whcih create /tmp/rostest_bin_hook/python so did not fail with rostest
+  - if [ "${ROS_DISTRO_NAME}" == "noetic" ]; then (cd /tmp/ros_buildfarm; sed -i "/^# After all dependencies are installed, update ccache symlinks./a @[if testing]@\nRUN apt-get install -qq -y wget patch\nRUN wget https://patch-diff.githubusercontent.com/raw/ros/ros_comm/pull/1879.diff -O /tmp/1879.diff\nRUN (cd /opt/ros/noetic/bin/; patch -R -p4 < /tmp/1879.diff )\n@[end if]@" ros_buildfarm/templates/devel/devel_task.Dockerfile.em); fi
+  - (mkdir -p $JOB_PATH; cp -r /tmp/ros_buildfarm $JOB_PATH) # copy to prevent from git clone ros_buildfarm
+  #
   - pip install /tmp/ros_buildfarm
   # checkout catkin for catkin_test_results script
   - git clone https://github.com/ros/catkin /tmp/catkin

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,11 +45,25 @@ catkin_package(
 )
 
 
-install(PROGRAMS bin/rosget bin/appmaster
+catkin_install_python(PROGRAMS bin/rosget bin/appmaster
  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
-install(DIRECTORY launch scripts test
+install(DIRECTORY launch test
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-  USE_SOURCE_PERMISSIONS)
+  USE_SOURCE_PERMISSIONS
+  PATTERN *.py EXCLUDE)
+file(GLOB_RECURSE TEST_FILES
+  RELATIVE "${PROJECT_SOURCE_DIR}"
+  "test/*.py")
+foreach(TEST_FILE ${TEST_FILES})
+  get_filename_component(DIR ${TEST_FILE} DIRECTORY)
+  catkin_install_python(PROGRAMS ${TEST_FILE}
+    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/${DIR})
+endforeach()
+file(GLOB SCRIPTS_FILES
+  RELATIVE "${PROJECT_SOURCE_DIR}"
+  "${PROJECT_SOURCE_DIR}/scripts/*")
+catkin_install_python(PROGRAMS ${SCRIPTS_FILES}
+ DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/scripts)
 
 if(CATKIN_ENABLE_TESTING)
   find_package(rostest)

--- a/bin/rosget
+++ b/bin/rosget
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import subprocess
 import sys

--- a/test/test_app.test
+++ b/test/test_app.test
@@ -10,7 +10,7 @@
   </node>
 
   <node pkg="rosservice" type="rosservice" name="start_app"
-	args="call --wait /robot/start_app '{ name : app_manager/appA, args: [{key: launch_prefix, value: python}]}'" />
+	args="call --wait /robot/start_app '{ name : app_manager/appA, args: [{key: launch_prefix, value: python$(env ROS_PYTHON_VERSION)}]}'" />
 
   <test test-name="hztest_test" pkg="rostest" type="hztest" name="hztest" >
     <param name="topic" value="/chatter" />


### PR DESCRIPTION
revert https://github.com/ros/ros_comm/pull/1879 within ros_buildfarm, to check if `rostest` fails because of missing `catkin_install_python`