### PR TITLE
speeding up of app load: 40 seconds -> 4 seconds

### DIFF
--- a/src/app_manager/app.py
+++ b/src/app_manager/app.py
@@ -153,12 +153,12 @@ def load_Interface_from_file(filename):
     """
     with open(filename,'r') as f:
         y = yaml.load(f.read())
-        y = y or {} #coerce to dict
-        try:
-            subscribed_topics = y.get('subscribed_topics', {})
-            published_topics = y.get('published_topics', {})
-        except KeyError:
-            raise InvalidAppException("Malformed interface, missing keys")
+    y = y or {} #coerce to dict
+    try:
+        subscribed_topics = y.get('subscribed_topics', {})
+        published_topics = y.get('published_topics', {})
+    except KeyError:
+        raise InvalidAppException("Malformed interface, missing keys")
     return Interface(published_topics=published_topics, subscribed_topics=subscribed_topics)
 
 def _AppDefinition_load_icon_entry(app_data, appfile="UNKNOWN"):
@@ -293,22 +293,22 @@ def load_AppDefinition_from_file(appfile, appname):
     """
     with open(appfile,'r') as f:
         app_data = yaml.load(f.read())
-        for reqd in ['launch', 'interface', 'platform']:
-            if not reqd in app_data:
-                raise InvalidAppException("Malformed appfile [%s], missing required key [%s]"%(appfile, reqd))
+    for reqd in ['launch', 'interface', 'platform']:
+        if not reqd in app_data:
+            raise InvalidAppException("Malformed appfile [%s], missing required key [%s]"%(appfile, reqd))
 
-        display_name = app_data.get('display', appname)
-        description = app_data.get('description', '')        
-        platform = app_data['platform']
+    display_name = app_data.get('display', appname)
+    description = app_data.get('description', '')
+    platform = app_data['platform']
 
 
-        launch = _AppDefinition_load_launch_entry(app_data, appfile)
-        interface = _AppDefinition_load_interface_entry(app_data, appfile)
-        clients = _AppDefinition_load_clients_entry(app_data, appfile)
-        icon = _AppDefinition_load_icon_entry(app_data, appfile)
-        plugins = _AppDefinition_load_plugins_entry(app_data, appfile)
-        plugin_order = _AppDefinition_load_plugin_order_entry(app_data, appfile)
-        timeout = _AppDefinition_load_timeout_entry(app_data, appfile)
+    launch = _AppDefinition_load_launch_entry(app_data, appfile)
+    interface = _AppDefinition_load_interface_entry(app_data, appfile)
+    clients = _AppDefinition_load_clients_entry(app_data, appfile)
+    icon = _AppDefinition_load_icon_entry(app_data, appfile)
+    plugins = _AppDefinition_load_plugins_entry(app_data, appfile)
+    plugin_order = _AppDefinition_load_plugin_order_entry(app_data, appfile)
+    timeout = _AppDefinition_load_timeout_entry(app_data, appfile)
 
     return AppDefinition(appname, display_name, description, platform,
                          launch, interface, clients, icon,

--- a/src/app_manager/app.py
+++ b/src/app_manager/app.py
@@ -128,16 +128,9 @@ def find_resource(resource, rospack=None):
     if not p:
         raise ValueError("Resource is missing package name: %s"%(resource))
 
-    # roslib.packages.find_resource is too slow
-    # matches = roslib.packages.find_resource(p, a)
     if rospack is None:
         rospack = rospkg.RosPack()
-    pkg_path = rospack.get_path(p)
-    matches = []
-    for dirpath, dirnames, filenames in os.walk(pkg_path):
-        for filename in filenames:
-            if filename == a:
-                matches.append(os.path.join(dirpath, filename))
+    matches = roslib.packages.find_resource(p, a, rospack=rospack)
 
     # TODO: convert ValueError to better type for better error messages
     if len(matches) == 1:

--- a/src/app_manager/app.py
+++ b/src/app_manager/app.py
@@ -39,6 +39,7 @@ import errno
 import yaml
 
 import roslib.names
+import rospkg
 from rospkg import ResourceNotFound
 from .exceptions import AppException, InvalidAppException, NotFoundException, InternalAppException
 
@@ -126,7 +127,17 @@ def find_resource(resource):
     p, a = roslib.names.package_resource_name(resource)
     if not p:
         raise ValueError("Resource is missing package name: %s"%(resource))
-    matches = roslib.packages.find_resource(p, a)
+
+    # roslib.packages.find_resource is too slow
+    # matches = roslib.packages.find_resource(p, a)
+    rospack = rospkg.RosPack()
+    pkg_path = rospack.get_path(p)
+    matches = []
+    for dirpath, dirnames, filenames in os.walk(pkg_path):
+        for filename in filenames:
+            if filename == a:
+                matches.append(os.path.join(dirpath, filename))
+
     # TODO: convert ValueError to better type for better error messages
     if len(matches) == 1:
         return matches[0]

--- a/src/app_manager/app_list.py
+++ b/src/app_manager/app_list.py
@@ -102,20 +102,20 @@ class InstalledFile(object):
         available_apps = []
         with open(self.filename) as f:
             installed_data = yaml.load(f)
-            for reqd in ['apps']:
-                if not reqd in installed_data:
-                    raise InvalidAppException("installed file [%s] is missing required key [%s]"%(self.filename, reqd))
-            for app in installed_data['apps']:
-                for areqd in ['app']:
-                    if not areqd in app:
-                        raise InvalidAppException("installed file [%s] app definition is missing required key [%s]"%(self.filename, areqd))
-                try:
-                    available_apps.append(load_AppDefinition_by_name(app['app']))
-                except NotFoundException as e:
-                    rospy.logerr(e)
-                    continue
-                except Exception as e:
-                    raise e
+        for reqd in ['apps']:
+            if not reqd in installed_data:
+                raise InvalidAppException("installed file [%s] is missing required key [%s]"%(self.filename, reqd))
+        for app in installed_data['apps']:
+            for areqd in ['app']:
+                if not areqd in app:
+                    raise InvalidAppException("installed file [%s] app definition is missing required key [%s]"%(self.filename, areqd))
+            try:
+                available_apps.append(load_AppDefinition_by_name(app['app']))
+            except NotFoundException as e:
+                rospy.logerr(e)
+                continue
+            except Exception as e:
+                raise e
 
         self.available_apps = available_apps
 

--- a/src/app_manager/app_list.py
+++ b/src/app_manager/app_list.py
@@ -44,6 +44,8 @@ import rospy
 import sys
 import yaml
 
+import rospkg
+
 from .app import load_AppDefinition_by_name
 from .msg import App, ClientApp, KeyValue, Icon
 from .exceptions import AppException, InvalidAppException, NotFoundException
@@ -100,6 +102,7 @@ class InstalledFile(object):
 
     def _load(self):
         available_apps = []
+        rospack = rospkg.RosPack()
         with open(self.filename) as f:
             installed_data = yaml.load(f)
         for reqd in ['apps']:
@@ -110,7 +113,8 @@ class InstalledFile(object):
                 if not areqd in app:
                     raise InvalidAppException("installed file [%s] app definition is missing required key [%s]"%(self.filename, areqd))
             try:
-                available_apps.append(load_AppDefinition_by_name(app['app']))
+                available_apps.append(
+                    load_AppDefinition_by_name(app['app'], rospack=rospack))
             except NotFoundException as e:
                 rospy.logerr(e)
                 continue

--- a/src/app_manager/app_manager.py
+++ b/src/app_manager/app_manager.py
@@ -62,6 +62,9 @@ from .master_sync import MasterSync
 from .msg import App, AppList, StatusCodes, AppStatus, AppInstallationState, ExchangeApp
 from .srv import StartApp, StopApp, ListApps, ListAppsResponse, StartAppResponse, StopAppResponse, InstallApp, UninstallApp, GetInstallationState, UninstallAppResponse, InstallAppResponse, GetInstallationStateResponse, GetAppDetails, GetAppDetailsResponse
 
+# for profiling
+# import cProfile, pstats
+# from io import BytesIO as StringIO
 
 def _load_config_default(
         roslaunch_files, port, roslaunch_strs=None, loader=None, verbose=False,
@@ -179,10 +182,24 @@ class AppManager(object):
         if (self._exchange):
             self._exchange.update_local()
 
+        # for time profiling
+        # time profiling is commented out because it will slow down.
+        # comment in when you debug it
+        # start_time = time.time()
+        # pr = cProfile.Profile()
+        # pr.enable()
         self._app_list.update()
         self.publish_exchange_list_apps()
         self.publish_list_apps()
-        
+        # pr.disable()
+        # s = StringIO()
+        # sortby = 'cumulative'
+        # ps = pstats.Stats(pr, stream=s).sort_stats(sortby)
+        # ps.print_stats()
+        # print(s.getvalue())
+        # end_time = time.time()
+        # rospy.logerr('total time: {}'.format(end_time - start_time))
+
     def shutdown(self):
         if self._api_sync:
             self._api_sync.stop()

--- a/test/test_app.py
+++ b/test/test_app.py
@@ -163,9 +163,9 @@ class AppTest(unittest.TestCase):
 
         #monkey patch in for coverage
         import errno
-        def fake_load_enoent(*args):
+        def fake_load_enoent(*args, **kwargs):
             raise IOError(errno.ENOENT, "fnf")
-        def fake_load_gen(*args):
+        def fake_load_gen(*args, **kwargs):
             raise IOError()
         import app_manager.app
         load_actual = app_manager.app.load_AppDefinition_from_file


### PR DESCRIPTION
UPDATE: I update this PR to speed up more.

Loading apps takes long time, which drops my productivity.
~I change not to use `roslib.packages.find_resource` for speed up.~
I change to share the same `rospack` object between multiple functions to make  `roslib.packages.find_resource` faster.

Current `kinetic-devel` takes 39 seconds to load 12 app.
This PR reduces it to 4 seconds.

## `kinetic-devel` branch

```
[ERROR] [1640440511.654021]: total time: 39.4751198292
```

cProfile output

```
         67248708 function calls (62972939 primitive calls) in 39.464 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000   39.463   39.463 /home/knorth55/ros/vive_ws/src/PR2/app_manager/src/app_manager/app_list.py:215(update)
        1    0.000    0.000   39.462   39.462 /home/knorth55/ros/vive_ws/src/PR2/app_manager/src/app_manager/app_list.py:167(_load)
       14    0.000    0.000   39.451    2.818 /home/knorth55/ros/vive_ws/src/PR2/app_manager/src/app_manager/app_list.py:122(update)
        7    0.000    0.000   39.451    5.636 /home/knorth55/ros/vive_ws/src/PR2/app_manager/src/app_manager/app_list.py:93(__init__)
        7    0.000    0.000   39.451    5.636 /home/knorth55/ros/vive_ws/src/PR2/app_manager/src/app_manager/app_list.py:101(_load)
       25    0.000    0.000   39.431    1.577 /home/knorth55/ros/vive_ws/src/PR2/app_manager/src/app_manager/app.py:306(load_AppDefinition_by_name)
      100    0.041    0.000   39.352    0.394 /home/knorth55/ros/vive_ws/src/PR2/app_manager/src/app_manager/app.py:117(find_resource)
      100    0.002    0.000   39.310    0.393 /opt/ros/melodic/lib/python2.7/dist-packages/roslib/packages.py:487(find_resource)
       25    0.001    0.000   29.561    1.182 /home/knorth55/ros/vive_ws/src/PR2/app_manager/src/app_manager/app.py:278(load_AppDefinition_from_file)
      100    0.027    0.000   27.902    0.279 /opt/ros/melodic/lib/python2.7/dist-packages/catkin/find_in_workspaces.py:95(find_in_workspaces)
    12148    0.062    0.000   27.395    0.002 /usr/local/lib/python2.7/dist-packages/catkin_pkg/packages.py:75(find_packages)
    12148    0.084    0.000   27.324    0.002 /usr/local/lib/python2.7/dist-packages/catkin_pkg/packages.py:112(find_packages_allowing_duplicates)
    12148    1.674    0.000   25.028    0.002 /usr/local/lib/python2.7/dist-packages/catkin_pkg/package.py:583(parse_package_string)
4152808/188764    4.308    0.000   11.479    0.000 /usr/lib/python2.7/copy.py:145(deepcopy)
      100    0.000    0.000   11.206    0.112 /usr/lib/python2.7/dist-packages/rospkg/rospack.py:199(get_path)
      100    0.117    0.001   11.205    0.112 /usr/lib/python2.7/dist-packages/rospkg/rospack.py:173(_update_location_cache)
    32500    0.863    0.000   11.088    0.000 /usr/lib/python2.7/dist-packages/rospkg/rospack.py:49(list_by_path)
   188764    1.031    0.000    9.937    0.000 /usr/lib/python2.7/copy.py:306(_reconstruct)
       25    0.000    0.000    9.837    0.393 /home/knorth55/ros/vive_ws/src/PR2/app_manager/src/app_manager/app.py:191(_AppDefinition_load_interface_entry)
       25    0.000    0.000    9.836    0.393 /home/knorth55/ros/vive_ws/src/PR2/app_manager/src/app_manager/app.py:153(_AppDefinition_load_icon_entry)
       25    0.000    0.000    9.832    0.393 /home/knorth55/ros/vive_ws/src/PR2/app_manager/src/app_manager/app.py:174(_AppDefinition_load_launch_entry)
   377528    1.017    0.000    7.454    0.000 /usr/lib/python2.7/copy.py:234(_deepcopy_tuple)
     6472    0.296    0.000    5.672    0.001 /usr/local/lib/python2.7/dist-packages/catkin_pkg/package.py:115(__getattr__)
327164/163962    0.888    0.000    5.613    0.000 /usr/lib/python2.7/os.py:209(walk)
```

## This PR

```
[ERROR] [1640619177.785652]: total time: 4.10533118248
```