### PR TITLE
Add run option in app file descripition

### DIFF
--- a/src/app_manager/app.py
+++ b/src/app_manager/app.py
@@ -204,6 +204,19 @@ def _AppDefinition_load_launch_entry(app_data, appfile="UNKNOWN", rospack=None):
     except ResourceNotFound as e:
         raise InvalidAppException("App file [%s] refers to package that is not installed: %s"%(appfile, str(e)))
 
+def _AppDefinition_load_run_args_entry(app_data, appfile="UNKNOWN"):
+    """
+    @raise InvalidAppException: if app definition is invalid.
+    """
+    # load/validate launch entry
+    try:
+        run_args = app_data.get('run_args', '')
+        if run_args == '':
+            return None
+        return run_args
+    except ValueError as e:
+        raise InvalidAppException("Malformed appfile [%s]: bad run_args entry: %s"%(appfile, e))
+
 def _AppDefinition_load_run_entry(app_data, appfile="UNKNOWN", rospack=None):
     """
     @raise InvalidAppExcetion: if app definition is invalid.
@@ -222,7 +235,8 @@ def _AppDefinition_load_run_entry(app_data, appfile="UNKNOWN", rospack=None):
             raise InvalidAppException("Malformed appfile [%s]: refers to run that does not exist."%(appfile))
         # create node
         p, a = roslib.names.package_resource_name(run_resource)
-        node = roslaunch.core.Node(p, a, output='screen')
+        args = _AppDefinition_load_run_args_entry(app_data, appfile)
+        node = roslaunch.core.Node(p, a, args=args, output='screen')
         return node
     except ValueError as e:
         raise InvalidAppException("Malformed appfile [%s]: bad run entry: %s"%(appfile, e))

--- a/src/app_manager/app.py
+++ b/src/app_manager/app.py
@@ -38,6 +38,7 @@ import os
 import errno
 import yaml
 
+import roslaunch
 import roslib.names
 import rospkg
 from rospkg import ResourceNotFound
@@ -214,10 +215,15 @@ def _AppDefinition_load_run_entry(app_data, appfile="UNKNOWN", rospack=None):
         run_resource = app_data.get('run', '')
         if run_resource == '':
             return None
+
+        # check if file exists
         run = find_resource(run_resource, rospack=rospack)
         if not os.path.exists(run):
             raise InvalidAppException("Malformed appfile [%s]: refers to run that does not exist."%(appfile))
-        return run
+        # create node
+        p, a = roslib.names.package_resource_name(run_resource)
+        node = roslaunch.core.Node(p, a, output='screen')
+        return node
     except ValueError as e:
         raise InvalidAppException("Malformed appfile [%s]: bad run entry: %s"%(appfile, e))
     except NotFoundException:

--- a/src/app_manager/app_list.py
+++ b/src/app_manager/app_list.py
@@ -202,6 +202,12 @@ class AppList(object):
             self.update()
         return [AppDefinition_to_App(ad) for ad in self.app_list]
 
+    def get_app(self, name):
+        for app in self.app_list:
+            if app.name == name:
+                return app
+        return None
+
     def add_directory(self, directory):
         if not os.path.exists(directory):
             raise IOError("applist directory %s does not exist." % directory)

--- a/src/app_manager/app_manager.py
+++ b/src/app_manager/app_manager.py
@@ -297,12 +297,13 @@ class AppManager(object):
             else:
                 self.stop_app(self._current_app_definition.name)
 
-        # TODO: the app list has already loaded the App data.  We should use that instead for consistency
-
         appname = req.name
         rospy.loginfo("Loading app: %s"%(appname))
         try:
-            app = load_AppDefinition_by_name(appname)
+            if self._app_list and self._app_list.get_app(appname):
+                app = self._app_list.get_app(appname)
+            else:
+                app = load_AppDefinition_by_name(appname)
         except ValueError as e:
             return StartAppResponse(started=False, message=str(e), error_code=StatusCodes.BAD_REQUEST)
         except InvalidAppException as e:

--- a/src/app_manager/app_manager.py
+++ b/src/app_manager/app_manager.py
@@ -522,6 +522,7 @@ class AppManager(object):
                 exit_codes = [p.exit_code for p in self._launch.pm.dead_list]
                 self._exit_code = max(exit_codes)
         if self._current_process:
+            self._current_process.stop()
             if (self._exit_code is None
                     and len(self._default_launch.pm.dead_list) > 0):
                 self._exit_code = self._default_launch.pm.dead_list[0].exit_code

--- a/src/app_manager/app_manager.py
+++ b/src/app_manager/app_manager.py
@@ -532,12 +532,14 @@ class AppManager(object):
         if self._launch:
             self._launch.shutdown()
             if (self._exit_code is None
+                    and self._launch.pm
                     and len(self._launch.pm.dead_list) > 0):
                 exit_codes = [p.exit_code for p in self._launch.pm.dead_list]
                 self._exit_code = max(exit_codes)
         if self._current_process:
             self._current_process.stop()
             if (self._exit_code is None
+                    and self._default_launch.pm
                     and len(self._default_launch.pm.dead_list) > 0):
                 self._exit_code = self._default_launch.pm.dead_list[0].exit_code
         if not self._exit_code is None and self._exit_code > 0:

--- a/src/app_manager/app_manager.py
+++ b/src/app_manager/app_manager.py
@@ -638,18 +638,11 @@ class AppManager(object):
             now = rospy.Time.now()
             if launch:
                 pm = launch.pm
-                if pm:
-                    procs = pm.procs[:]
-                    if len(procs) > 0:
-                        if any([p.required for p in procs]):
-                            exit_codes = [
-                                p.exit_code for p in procs if p.required]
-                            self._exit_code = max(exit_codes)
-                    if pm.done:
-                        time.sleep(1.0)
-                        if not self._stopping:
-                            self.stop_app(appname)
-                        break
+                if pm and pm.done:
+                    time.sleep(1.0)
+                    if not self._stopping:
+                        self.stop_app(appname)
+                    break
                 if (timeout is not None and
                         self._start_time is not None and
                         (now - self._start_time).to_sec() > timeout):

--- a/src/app_manager/app_manager.py
+++ b/src/app_manager/app_manager.py
@@ -455,7 +455,8 @@ class AppManager(object):
                         self._plugin_insts[plugin['module']] = plugin_inst
                     if 'run' in plugin and plugin['run']:
                         p, a = roslib.names.package_resource_name(plugin['run'])
-                        node = roslaunch.core.Node(p, a, output='screen')
+                        args = plugin.get('run_args', None)
+                        node = roslaunch.core.Node(p, a, args=args, output='screen')
                         proc, success = self._default_launch.runner.launch_node(node)
                         if not success:
                             raise roslaunch.core.RLException(

--- a/src/app_manager/app_manager.py
+++ b/src/app_manager/app_manager.py
@@ -204,9 +204,11 @@ class AppManager(object):
         # end_time = time.time()
         # rospy.logerr('total time: {}'.format(end_time - start_time))
 
+        # show_summary keyword is added in melodic
+        # removing for kinetic compability
         rospy.loginfo("Initializing default launcher")
         self._default_launch = roslaunch.parent.ROSLaunchParent(
-            rospy.get_param("/run_id"), [], is_core=False, show_summary=False)
+            rospy.get_param("/run_id"), [], is_core=False)
         self._default_launch.start(auto_terminate=False)
 
     def shutdown(self):

--- a/src/app_manager/app_manager.py
+++ b/src/app_manager/app_manager.py
@@ -172,6 +172,7 @@ class AppManager(object):
         self._exit_code = None
         self._stopped = None
         self._stopping = None
+        self._current_process = None
         self._current_plugins = None
         self._plugin_context = None
         self._plugin_insts = None
@@ -199,6 +200,11 @@ class AppManager(object):
         # print(s.getvalue())
         # end_time = time.time()
         # rospy.logerr('total time: {}'.format(end_time - start_time))
+
+        rospy.loginfo("Initializing default launcher")
+        self._default_launch = roslaunch.parent.ROSLaunchParent(
+            rospy.get_param("/run_id"), [], is_core=False, show_summary=False)
+        self._default_launch.start(auto_terminate=False)
 
     def shutdown(self):
         if self._api_sync:
@@ -316,15 +322,17 @@ class AppManager(object):
 
             self._status_pub.publish(AppStatus(AppStatus.INFO, 'launching %s'%(app.display_name)))
 
-            if len(req.args) == 0:
-                launch_files = [app.launch]
-                rospy.loginfo("Launching: {}".format(app.launch))
-            else:
-                app_launch_args = []
-                for arg in req.args:
-                    app_launch_args.append("{}:={}".format(arg.key, arg.value))
-                launch_files = [(app.launch, app_launch_args)]
-                rospy.loginfo("Launching: {} {}".format(app.launch, app_launch_args))
+            launch_files = []
+            if app.launch:
+                if len(req.args) == 0:
+                    launch_files = [app.launch]
+                    rospy.loginfo("Launching: {}".format(app.launch))
+                else:
+                    app_launch_args = []
+                    for arg in req.args:
+                        app_launch_args.append("{}:={}".format(arg.key, arg.value))
+                    launch_files = [(app.launch, app_launch_args)]
+                    rospy.loginfo("Launching: {} {}".format(app.launch, app_launch_args))
 
             plugin_launch_files = []
             if app.plugins:
@@ -380,20 +388,27 @@ class AppManager(object):
                             .format(app_plugin_type))
 
             #TODO:XXX This is a roslaunch-caller-like abomination.  Should leverage a true roslaunch API when it exists.
-            self._launch = roslaunch.parent.ROSLaunchParent(
-                rospy.get_param("/run_id"), launch_files,
-                is_core=False, process_listeners=())
+            if app.launch:
+                self._launch = roslaunch.parent.ROSLaunchParent(
+                    rospy.get_param("/run_id"), launch_files,
+                    is_core=False, process_listeners=())
             if len(plugin_launch_files) > 0:
                 self._plugin_launch = roslaunch.parent.ROSLaunchParent(
                     rospy.get_param("/run_id"), plugin_launch_files,
                     is_core=False, process_listeners=())
 
-            self._launch._load_config()
+            if self._launch:
+                self._launch._load_config()
             if self._plugin_launch:
                 self._plugin_launch._load_config()
 
             #TODO: convert to method
-            for N in self._launch.config.nodes:
+            nodes = []
+            if self._launch:
+                nodes.extend(self._launch.config.nodes)
+            if app.run:
+                nodes.append(app.run)
+            for N in nodes:
                 for t in app.interface.published_topics.keys():
                     N.remap_args.append((t, self._app_interface + '/' + t))
                 for t in app.interface.subscribed_topics.keys():
@@ -440,7 +455,16 @@ class AppManager(object):
                 self._plugin_launch.start()
 
             # finally launch main launch
-            self._launch.start()
+            if self._launch:
+                self._launch.start()
+            if app.run:
+                node = app.run
+                proc, success = self._default_launch.runner.launch_node(node)
+                if not success:
+                    raise roslaunch.core.RLException(
+                        "failed to launch %s/%s"%(node.package, node.type))
+                self._current_process = proc
+
             if app.timeout is not None:
                 self._start_time = rospy.Time.now()
 
@@ -449,7 +473,10 @@ class AppManager(object):
 
             self._interface_sync = MasterSync(self._interface_master, foreign_pub_names=fp, local_pub_names=lp)
 
-            thread.start_new_thread(self.app_monitor,())
+            if app.launch:
+                thread.start_new_thread(self.app_monitor, ())
+            if app.run:
+                thread.start_new_thread(self.process_monitor, ())
 
             return StartAppResponse(started=True, message="app [%s] started"%(appname), namespace=self._app_interface)
         
@@ -478,6 +505,7 @@ class AppManager(object):
             self._exit_code = None
             self._stopped = None
             self._stopping = None
+            self._current_process = None
             self._current_plugins = None
             self._plugin_context = None
             self._plugin_insts = None
@@ -495,9 +523,13 @@ class AppManager(object):
             if (self._exit_code is None
                     and len(self._launch.pm.dead_list) > 0):
                 self._exit_code = self._launch.pm.dead_list[0].exit_code
-            if not self._exit_code is None and self._exit_code > 0:
-                rospy.logerr(
-                    "App stopped with exit code: {}".format(self._exit_code))
+        if self._current_process:
+            if (self._exit_code is None
+                    and len(self._default_launch.pm.dead_list) > 0):
+                self._exit_code = self._default_launch.pm.dead_list[0].exit_code
+        if not self._exit_code is None and self._exit_code > 0:
+            rospy.logerr(
+                "App stopped with exit code: {}".format(self._exit_code))
         if self._plugin_launch:
             self._plugin_launch.shutdown()
         if self._current_plugins:
@@ -574,6 +606,29 @@ class AppManager(object):
             rospy.logerr("Failed to reload app list: %s" % e)
         return EmptyResponse()
 
+    def process_monitor(self):
+        while self._current_process:
+            time.sleep(0.1)
+            proc = self._current_process
+            timeout = self._current_app_definition.timeout
+            appname = self._current_app_definition.name
+            now = rospy.Time.now()
+            if proc:
+                if proc.stopped:
+                    time.sleep(1.0)
+                    if not self._stopping:
+                        self.stop_app(appname)
+                    break
+                if (timeout is not None and
+                    self._start_time is not None and
+                    (now - self._start_time).to_sec() > timeout):
+                    self._stopped = True
+                    self.stop_app(appname)
+                    rospy.logerr(
+                        'app {} is stopped because of timeout: {}s'.format(
+                            appname, timeout))
+                    break
+
     def app_monitor(self):
         while self._launch:
             time.sleep(0.1)
@@ -622,7 +677,7 @@ class AppManager(object):
                 resp.message = "app %s is not running"%(appname)                    
             else:
                 try:
-                    if self._launch:
+                    if self._launch or self._current_process:
                         rospy.loginfo("handle stop app: stopping app [%s]"%(appname))
                         self._status_pub.publish(AppStatus(AppStatus.INFO, 'stopping %s'%(app.display_name)))
                         self._stop_current()
@@ -635,6 +690,7 @@ class AppManager(object):
                         resp.error_code = StatusCodes.NOT_RUNNING
                 finally:
                     self._launch = None
+                    self._current_process = None
                     self._set_current_app(None, None)
 
         except Exception as e:

--- a/src/app_manager/app_manager.py
+++ b/src/app_manager/app_manager.py
@@ -519,7 +519,8 @@ class AppManager(object):
             self._launch.shutdown()
             if (self._exit_code is None
                     and len(self._launch.pm.dead_list) > 0):
-                self._exit_code = self._launch.pm.dead_list[0].exit_code
+                exit_codes = [p.exit_code for p in self._launch.pm.dead_list]
+                self._exit_code = max(exit_codes)
         if self._current_process:
             if (self._exit_code is None
                     and len(self._default_launch.pm.dead_list) > 0):


### PR DESCRIPTION
Allows to set a `run` option to designate a rosrun executable. When compared to the current `launch` option, the `run` allows to start the app much faster (the launch node initialization takes about 1 second).

This has been running in the real robot daily without a problem.

Example usage:
https://github.com/knorth55/jsk_robot/blob/fetch15/jsk_fetch_robot/jsk_fetch_startup/apps/time_signal/time_signal.app#L3