### PR TITLE
Add sigint and sigterm timeout arg to ROSLaunchParent initialization

### DIFF
--- a/launch/app_manager.launch
+++ b/launch/app_manager.launch
@@ -3,6 +3,8 @@
   <arg name="master" default="true" doc="launch master if enabled"/>
   <arg name="master_address" default="localhost" doc="address for app_manager master"/>
   <arg name="master_port" default="11313" doc="port for app_manager master"/>
+  <arg name="sigint_timeout" default="15.0" doc="Time between sending sigint and sending sigterm to ROSLaunchParent"/>
+  <arg name="sigterm_timeout" default="2.0" doc="Time between sending sigterm and sending sigkill to ROSLaunchParent"/>
 
   <!-- app list -->
   <arg name="use_applist" default="false" doc="load apps from applist argument"/>
@@ -21,5 +23,7 @@
         args="$(arg app_manager_args)"
         output="screen" respawn="$(arg respawn)">
     <param name="interface_master" value="http://$(arg master_address):$(arg master_port)"/>
+    <param name="sigint_timeout" value="$(arg sigint_timeout)"/>
+    <param name="sigterm_timeout" value="$(arg sigterm_timeout)"/>
   </node>
 </launch>

--- a/scripts/app_manager
+++ b/scripts/app_manager
@@ -64,6 +64,8 @@ def main():
 
     robot_name = rospy.get_param('/robot/name', 'robot')
     robot_type = rospy.get_param("/robot/type", None)
+    sigint_timeout = rospy.get_param("~sigint_timeout", 15.0)
+    sigterm_timeout = rospy.get_param("~sigterm_timeout", 2.0)
     if robot_type is None:
         rospy.loginfo("The param '/robot/type' is undefined. Using apps for any platforms")
     else:
@@ -95,7 +97,8 @@ def main():
 
     am = app_manager.AppManager(
         robot_name, interface_master, app_list, exchange, plugins,
-        enable_app_replacement=enable_app_replacement)
+        enable_app_replacement=enable_app_replacement,
+        sigint_timeout=sigint_timeout, sigterm_timeout=sigterm_timeout)
 
     rospy.on_shutdown(am.shutdown)
 

--- a/src/app_manager/app_manager.py
+++ b/src/app_manager/app_manager.py
@@ -210,10 +210,16 @@ class AppManager(object):
         # show_summary keyword is added in melodic
         # removing for kinetic compability
         rospy.loginfo("Initializing default launcher")
-        self._default_launch = roslaunch.parent.ROSLaunchParent(
-            rospy.get_param("/run_id"), [], is_core=False,
-            sigint_timeout=self._sigint_timeout,
-            sigterm_timeout=self._sigterm_timeout)
+        try:
+            self._default_launch = roslaunch.parent.ROSLaunchParent(
+                rospy.get_param("/run_id"), [], is_core=False,
+                sigint_timeout=self._sigint_timeout,
+                sigterm_timeout=self._sigterm_timeout)
+        except TypeError:
+            # ROSLaunchParent() does not have sigint/sigterm_timeout argument
+            # if roslaunch < 1.14.13 or < 1.15.5
+            self._default_launch = roslaunch.parent.ROSLaunchParent(
+                rospy.get_param("/run_id"), [], is_core=False)
         self._default_launch.start(auto_terminate=False)
 
     def shutdown(self):
@@ -399,17 +405,31 @@ class AppManager(object):
 
             #TODO:XXX This is a roslaunch-caller-like abomination.  Should leverage a true roslaunch API when it exists.
             if app.launch:
-                self._launch = roslaunch.parent.ROSLaunchParent(
-                    rospy.get_param("/run_id"), launch_files,
-                    is_core=False, process_listeners=(),
-                    sigint_timeout=self._sigint_timeout,
-                    sigterm_timeout=self._sigterm_timeout)
+                try:
+                    self._launch = roslaunch.parent.ROSLaunchParent(
+                        rospy.get_param("/run_id"), launch_files,
+                        is_core=False, process_listeners=(),
+                        sigint_timeout=self._sigint_timeout,
+                        sigterm_timeout=self._sigterm_timeout)
+                except TypeError:
+                    # ROSLaunchParent() does not have sigint/sigterm_timeout argument
+                    # if roslaunch < 1.14.13 or < 1.15.5
+                    self._launch = roslaunch.parent.ROSLaunchParent(
+                        rospy.get_param("/run_id"), launch_files,
+                        is_core=False, process_listeners=())
             if len(plugin_launch_files) > 0:
-                self._plugin_launch = roslaunch.parent.ROSLaunchParent(
-                    rospy.get_param("/run_id"), plugin_launch_files,
-                    is_core=False, process_listeners=(),
-                    sigint_timeout=self._sigint_timeout,
-                    sigterm_timeout=self._sigterm_timeout)
+                try:
+                    self._plugin_launch = roslaunch.parent.ROSLaunchParent(
+                        rospy.get_param("/run_id"), plugin_launch_files,
+                        is_core=False, process_listeners=(),
+                        sigint_timeout=self._sigint_timeout,
+                        sigterm_timeout=self._sigterm_timeout)
+                except TypeError:
+                    # ROSLaunchParent() does not have sigint/sigterm_timeout argument
+                    # if roslaunch < 1.14.13 or < 1.15.5
+                    self._plugin_launch = roslaunch.parent.ROSLaunchParent(
+                        rospy.get_param("/run_id"), plugin_launch_files,
+                        is_core=False, process_listeners=())
 
             if self._launch:
                 self._launch._load_config()

--- a/src/app_manager/app_manager.py
+++ b/src/app_manager/app_manager.py
@@ -125,6 +125,7 @@ class AppManager(object):
     def __init__(
             self, robot_name, interface_master, app_list,
             exchange, plugins=None, enable_app_replacement=True,
+            sigint_timeout=15.0, sigterm_timeout=2.0,
     ):
         self._robot_name = robot_name
         self._interface_master = interface_master
@@ -133,6 +134,8 @@ class AppManager(object):
         self._exchange = exchange
         self._plugins = plugins
         self._enable_app_replacement = enable_app_replacement
+        self._sigint_timeout = sigint_timeout
+        self._sigterm_timeout = sigterm_timeout
             
         rospy.loginfo("Starting app manager for %s"%self._robot_name)
 
@@ -396,11 +399,15 @@ class AppManager(object):
             if app.launch:
                 self._launch = roslaunch.parent.ROSLaunchParent(
                     rospy.get_param("/run_id"), launch_files,
-                    is_core=False, process_listeners=())
+                    is_core=False, process_listeners=(),
+                    sigint_timeout=self._sigint_timeout,
+                    sigterm_timeout=self._sigterm_timeout)
             if len(plugin_launch_files) > 0:
                 self._plugin_launch = roslaunch.parent.ROSLaunchParent(
                     rospy.get_param("/run_id"), plugin_launch_files,
-                    is_core=False, process_listeners=())
+                    is_core=False, process_listeners=(),
+                    sigint_timeout=self._sigint_timeout,
+                    sigterm_timeout=self._sigterm_timeout)
 
             if self._launch:
                 self._launch._load_config()

--- a/src/app_manager/app_manager.py
+++ b/src/app_manager/app_manager.py
@@ -211,7 +211,9 @@ class AppManager(object):
         # removing for kinetic compability
         rospy.loginfo("Initializing default launcher")
         self._default_launch = roslaunch.parent.ROSLaunchParent(
-            rospy.get_param("/run_id"), [], is_core=False)
+            rospy.get_param("/run_id"), [], is_core=False,
+            sigint_timeout=self._sigint_timeout,
+            sigterm_timeout=self._sigterm_timeout)
         self._default_launch.start(auto_terminate=False)
 
     def shutdown(self):


### PR DESCRIPTION
This PR adds `sigint_timeout` and `sigterm_timeout` arg to roslaunch initialization in app_manager.

In my case, the problem occurred when using rosbag record from roslaunch.
At the end of rosbag record with large file size, the default `sigint_timeout` (15 seconds) does not allow sigint to execute successfully.

With this pull request, the `sigint_timeout` can be extended, the rosbag record can be terminated with sigint successfully, and the rosbag file can be saved.

Note that giving `sigint_timeout` and `sigterm_timeout` to roslaunch is available since `roslaunch >= 1.14.13`, released for only melodic and noetic.