### PR TITLE
Fix topic remapping

### DIFF
--- a/src/app_manager/app_manager.py
+++ b/src/app_manager/app_manager.py
@@ -453,7 +453,7 @@ class AppManager(object):
             if app.run:
                 nodes.append(app.run)
             if self._enable_topic_remapping:
-                for N in self._launch.config.nodes:
+                for N in nodes:
                     for t in app.interface.published_topics.keys():
                         N.remap_args.append((t, self._app_interface + '/' + t))
                     for t in app.interface.subscribed_topics.keys():


### PR DESCRIPTION
time_signal app which use the run tag failed.
```
[ERROR] [1664931600.857071] [/app_manager:rosout]: Traceback (most recent call last):
  File "/home/fetch/ros/melodic/src/PR2/app_manager/src/app_manager/app_manager.py", line 456, in handle_start_app
    for N in self._launch.config.nodes:
AttributeError: 'NoneType' object has no attribute 'config'
```